### PR TITLE
FHIR-55560: Use R5 cross-version Extension for DiagnosticReport.media.link

### DIFF
--- a/input/fsh/alias-lab.fsh
+++ b/input/fsh/alias-lab.fsh
@@ -58,6 +58,7 @@ Alias: $recordedSexOrGender = http://hl7.org/fhir/StructureDefinition/individual
 Alias: $workflow-supportingInfo = http://hl7.org/fhir/StructureDefinition/workflow-supportingInfo
 Alias: $observation-triggeredBy-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy
 Alias: $observation-value-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value[x]
+Alias: $diagnosticReport-link-xver = http://hl7.org/fhir/StructureDefinition/alternate-reference
 
 
 // --- Profiles

--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -84,7 +84,19 @@ Commented based on the suggestion form the 2023-05-26 meeting see https://github
   * comment
     * ^short = "Comment about the image or data (e.g. explanation)"
     * ^definition = "Allows for a comment about the image or data, such as an explanation of its significance or context within the diagnostic report."
-    * ^requirements = "The provider of the report should make a comment about each image or data included in the report. This comment can provide valuable context and help the reader understand the significance of the image or data in relation to the overall findings of the report."
+    * ^requirements = "The provider of the report should make a comment about each image or data included in the report. This comment can provide valuable context and help the reader understand the significance of the image or data in relation to the overall findings of the report."  
   * link
     * ^short = "Reference to the image or data"
     * ^definition = "A reference to the image or data associated with this report."
+    * reference 0..0
+    * type 0..0
+    * identifier 0..0
+    * display 1..1
+      * ^definition = "Text stating that instead of a reference to a Media resource, a DocumentReference resource is linked through the cross-version extension 'link'."
+      * ^short = "Text stating use of cross-version extension 'link'"
+    * extension contains $diagnosticReport-link-xver named link 0..1
+    * extension[link]
+      * ^definition = "Reference to a DocumentReference containing additional information/attachments associated with this report."
+      * ^short = "DocumentReference containing additional information/attachments"
+      * valueReference 1..1
+      * valueReference only Reference(DocumentReference) 

--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -98,5 +98,4 @@ Commented based on the suggestion form the 2023-05-26 meeting see https://github
     * extension[link]
       * ^definition = "Reference to a DocumentReference containing additional information/attachments associated with this report."
       * ^short = "DocumentReference containing additional information/attachments"
-      * valueReference 1..1
       * valueReference only Reference(DocumentReference) 


### PR DESCRIPTION
Jira ticket: https://jira.hl7.org/browse/FHIR-55560

* Add cross-version extension [alternate-reference](http://hl7.org/fhir/extensions/5.2.0/StructureDefinition-alternate-reference.html) to element DiagnosticReport.media.link
* Constrain DiagnosticReport.media.link.extension[link].valueReference to DocumentReference
* Set DiagnosticReport.media.link.reference, .type and .identifier to 0..0
* Set DiagnosticReport.media.link.display to 1..1 and add appropriate definition and short explaining purpose and requiered content of this element