### PR TITLE
53529 remove ips data types

### DIFF
--- a/input/fsh/alias-lab.fsh
+++ b/input/fsh/alias-lab.fsh
@@ -59,39 +59,5 @@ Alias: $diagnosticReport-link-xver = http://hl7.org/fhir/StructureDefinition/alt
 
 
 // --- Profiles
-Alias: $Composition-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Composition-uv-ips
-Alias: $Patient-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips
-Alias: $AllergyIntolerance-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/AllergyIntolerance-uv-ips
-Alias: $Condition-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Condition-uv-ips
-Alias: $DeviceUseStatement-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/DeviceUseStatement-uv-ips
-Alias: $DiagnosticReport-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/DiagnosticReport-uv-ips
-Alias: $ImagingStudy-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/ImagingStudy-uv-ips
-Alias: $Immunization-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Immunization-uv-ips
-Alias: $Media-observation-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Media-observation-uv-ips
-Alias: $Medication-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Medication-uv-ips
-Alias: $MedicationRequest-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/MedicationRequest-uv-ips
-Alias: $MedicationStatement-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/MedicationStatement-uv-ips
-Alias: $Practitioner-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Practitioner-uv-ips
-Alias: $PractitionerRole-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/PractitionerRole-uv-ips
-Alias: $Procedure-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Procedure-uv-ips
-Alias: $Organization-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Organization-uv-ips
-Alias: $Observation-pregnancy-edd-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-pregnancy-edd-uv-ips
-Alias: $Observation-pregnancy-outcome-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-pregnancy-outcome-uv-ips
-Alias: $Observation-pregnancy-status-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-pregnancy-status-uv-ips
-Alias: $Observation-alcoholuse-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-alcoholuse-uv-ips
-Alias: $Observation-tobaccouse-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-tobaccouse-uv-ips
-Alias: $Observation-results-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-results-uv-ips
-//Alias: $Specimen-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Specimen-uv-ips
-Alias: $Bundle-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Bundle-uv-ips
-Alias: $vitalsigns = http://hl7.org/fhir/StructureDefinition/vitalsigns
-
-Alias: $CodeableConcept-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/CodeableConcept-uv-ips
-Alias: $ext-data-absent-reason = http://hl7.org/fhir/StructureDefinition/data-absent-reason
-
-Alias: $Range-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Range-uv-ips
-Alias: $Ratio-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Ratio-uv-ips
-Alias: $Quantity-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Quantity-uv-ips
-
-Alias: $Observation-results-laboratory-uv-ips = http://hl7.org/fhir/uv/ips/StructureDefinition/Observation-results-laboratory-uv-ips
 
 //=========================

--- a/input/fsh/profiles/composition-lab.fsh
+++ b/input/fsh/profiles/composition-lab.fsh
@@ -87,9 +87,6 @@ Variant 2: Text and Entry - With this option, the Laboratory Specialty Section t
 // ---------------------------------
 
 * insert SectionCommonRules
-/* * section.title 1..
-* section.code 1..
-* section.code only $CodeableConcept-uv-ips */
 
 // -------------------------------------
 // Single section  0 .. 1
@@ -112,14 +109,11 @@ Variant 2: Text and Entry - With this option, the Laboratory Specialty Section t
 * section[lab-subsections]
   * ^short = "Variant 2: EU Laboratory Report section with one to many subsections Laboratory Report Item"
   * ^definition = """Variant 2: With this option, this top level section doesn't include NEITHER a top level text NOR entry elements. Each Report Item is contained in a corresponding sub-sections which contains the Lab Report Data Entry."""
-  * code only $CodeableConcept-uv-ips
   * code from LabStudyTypesEuVs (preferred)
   * text 0..0
   * entry 0..0
   * insert SectionCommonRules
   * section 1..
-/*     * code 1..
-    * code only $CodeableConcept-uv-ips */
     * insert SectionElementsRules
     * code from LabStudyTypesEuVs (preferred)
 /*        * text ^short = "Text summary of the section, for human interpretation."

--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -49,7 +49,6 @@ Commented based on the suggestion form the 2023-05-26 meeting see https://github
 * insert ReportCategoryRule
 // add binding
 /* * code 1..
-* code only $CodeableConcept-uv-ips
 * code from LabReportTypesEuVs (preferred) // value set to be revised add alternative value sets
 * code ^binding.extension.extension[0].url = "purpose"
 * code ^binding.extension.extension[=].valueCode = #candidate

--- a/input/fsh/profiles/observation-lab.fsh
+++ b/input/fsh/profiles/observation-lab.fsh
@@ -31,7 +31,7 @@ This observation may represent the result of a simple laboratory test such as he
 * status ^short = "Status of this observation (e.g. preliminary, final,...)"
 
 * category 1..*
-* category only $CodeableConcept-uv-ips
+* category 
   * insert SliceElement (#value, #this)
   * ^definition = "A code that classifies the general type of observation being made."
   * ^comment = "\"laboratory\" includes laboratory medicine and pathology"
@@ -41,14 +41,11 @@ This observation may represent the result of a simple laboratory test such as he
   studyType 0..* and
   specialty 0..*
 * category[laboratory] = http://terminology.hl7.org/CodeSystem/observation-category#laboratory
-* category[studyType] only $CodeableConcept-uv-ips
 * category[studyType] from LabStudyTypesEuVs
 * category[studyType] ^short = "The way of grouping of the test results into clinically meaningful domains (e.g. hematology study, microbiology study, etc.)"
-* category[specialty] only $CodeableConcept-uv-ips
 * category[specialty] from LabSpecialtyEuVs
 * category[specialty] ^short = "The clinical domain of the laboratory performing the observation (e.g. microbiology, toxicology, chemistry)"
-
-* code only $CodeableConcept-uv-ips
+ 
 * code from LaboratoryResultStandardEuVs (preferred)  // new binding to EU test codes VS
 * code ^definition = "Describes what was observed. Sometimes this is called the observation \"name\".  In this profile this code represents either a simple laboratory test or a laboratory study with multiple child observations"
 * code ^comment = "In the context of this Observation-laboratory profile, when the observation plays the role of a grouper of member sub-observations, the code represent the group (for instance a panel code). In case no code is available, at least a text shall be provided."
@@ -58,11 +55,9 @@ This observation may represent the result of a simple laboratory test such as he
 * performer 1..
 * dataAbsentReason ^short = "Provides a reason why the expected value is missing."
 * insert ObservationResultsValueEu
-* interpretation only $CodeableConcept-uv-ips
 * method ^definition = "Laboratory technigue that has been used"
 * method ^comment = "Laboratory technique (method of measurement) are integral parts of the test specification of some laboratory test coding systems (e.g. NPU), in LOINC hovewer measurement principle is not always present in the test definition. In some cases however knowledge of the used measurment techique is important for proper interpretation of the test result.
 That's why it is important to explicitly include informaiton about measurement method is such cases."
-* method only $CodeableConcept-uv-ips
 * method from LabTechniqueEuVs (preferred) // added binding to an agreed eu lab measurement method value set
 * specimen only Reference(SpecimenEu)
   * ^comment = "When the specimen is applicable and known it shall be documented"
@@ -74,7 +69,6 @@ That's why it is important to explicitly include informaiton about measurement m
 * issued ^short = "Date/Time this result was made available"
 
 * component ^short = "Laboratory result"
-  * code only $CodeableConcept-uv-ips
   * code from LaboratoryResultStandardEuVs (preferred)
   * insert ObservationResultsValueEu
 

--- a/input/fsh/profiles/quantity-lab.fsh
+++ b/input/fsh/profiles/quantity-lab.fsh
@@ -2,8 +2,10 @@ Profile: QuantityEuLab
 Parent: Quantity
 Id: Quantity-eu-lab
 Title: "Quantity (Eu Lab)"
-Description: "This profile constrains the Quantity data type to use UCUM as the code system for units and optionally share measurement uncertainty"
-// * ^publisher = "HL7 Europe"
+Description: """This profile constrains the Quantity data type to use UCUM for units. 
+When using the Quantity datatype, the unit is represented using a coded form with UCUM as the system in the code element. The human-readable textual representation is is captured in the unit element.
+If no suitable UCUM code exists, the code is set to “1”, and the textual unit representation is used. 
+If both coded and textual representations are present, they need to be semantically consistent."""
 * ^purpose = "This profile of the Quantity data type imposes the usage of the UCUM as the code system for units and allows expressing uncertainty of measurement"
 * . ^short = "A measured amount using UCUM"
 * . ^definition = "A measured amount (or an amount that can potentially be measured) and uncertainty of the measurement. Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.\r\nThis profile imposes that the code system for units be UCUM."
@@ -12,7 +14,6 @@ Description: "This profile constrains the Quantity data type to use UCUM as the 
 * extension contains $iso21090-uncertaintyType named uncertaintyType 0..1
 * system = "http://unitsofmeasure.org" 
 * system 0..1
-
 
 Profile: RatioEuLab
 Parent: Ratio
@@ -39,7 +40,6 @@ Parent: Range
 Id: Range-eu-lab
 Title: "Range (Eu Lab)"
 Description: "This profile constrains the Range data type to use UCUM as the code system for units and optionally share measurement uncertainty"
-// * ^publisher = "HL7 Europe"
 * ^purpose = "This profile of the Range data type imposes the usage of the UCUM as the code system for units and allows expressing uncertainty of measurement"
 * . ^short = "A measured range using UCUM"
 * . ^definition = "A measured range (or a range that can potentially be measured) and uncertainty of the measurement. This profile imposes that the code system for units be UCUM."

--- a/input/fsh/rulesSet/observation-results.fsh
+++ b/input/fsh/rulesSet/observation-results.fsh
@@ -11,8 +11,7 @@ RuleSet: ObservationResultsValueEu
 // reverted to the original statement
 // * valueRange only Range-eu-lab
 * valueRange ^sliceName = "valueRange"
-//* valueRatio only $Ratio-uv-ips
-* valueRatio only Ratio-eu-lab
+* valueRatio only RatioEuLab
 * valueRatio ^sliceName = "valueRatio"
 * valueTime only time
 * valueTime ^sliceName = "valueTime"
@@ -20,12 +19,8 @@ RuleSet: ObservationResultsValueEu
 * valueDateTime ^sliceName = "valueDateTime"
 * valuePeriod only Period
 * valuePeriod ^sliceName = "valuePeriod"
-// * valueQuantity only $Quantity-uv-ips
-* valueQuantity only Quantity-eu-lab
-// * valueQuantity MS
+* valueQuantity only QuantityEuLab
 * valueQuantity ^sliceName = "valueQuantity"
-* valueCodeableConcept only $CodeableConcept-uv-ips
-// * valueCodeableConcept MS
 * valueCodeableConcept from $results-coded-values-laboratory-pathology-uv-ips (preferred)
 * valueCodeableConcept ^sliceName = "valueCodeableConcept"
 * valueCodeableConcept ^binding.extension[0].extension[0].url = "purpose"

--- a/input/fsh/rulesSet/rulesSet-common.fsh
+++ b/input/fsh/rulesSet/rulesSet-common.fsh
@@ -65,7 +65,6 @@ RuleSet: SectionElementsRules
 RuleSet: SectionCommonRules
 * section.title 1..
 * section.code 1..
-* section.code only $CodeableConcept-uv-ips
 
 RuleSet: SNOMEDCopyrightForVS
 * ^copyright = "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement"

--- a/input/fsh/rulesSet/rulesSet-lab.fsh
+++ b/input/fsh/rulesSet/rulesSet-lab.fsh
@@ -37,7 +37,6 @@ RuleSet: ReportIdentifierRule
 RuleSet: ReportTypeRule (element)
 * {element} 1..
 /* * {element}  obeys labRpt-code */
-* {element}  only $CodeableConcept-uv-ips
 * {element}  from LabReportTypesEuVs (preferred) // value set to be revised add alternative value sets
   * ^short = "Type of (Laboratory) Report"
   * ^definition = "Specifies that it refers to a Laboratory Report"
@@ -49,13 +48,11 @@ RuleSet: ReportCategoryRule
   * ^short = "Report Category"
   * ^definition = "Specifies the Report Category: usually Laboratory"
   * ^comment = "DiagnosticReport.category and Composition.category shall be aligned"
-* category only $CodeableConcept-uv-ips
 * category ^slicing.discriminator.type = #value
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
 * category ^definition = "A code that classifies this laboratory report. Two basic categories has been selected in this guide: laboratory specialty and Study type. Laboratory specialty is characteristic of the laboratory that produced the test result while Study type is an arbitrary classificion of the test type."
 * category contains studyType 0..*
-* category[studyType] only $CodeableConcept-uv-ips
 * category[studyType] from LabStudyTypesEuVs
 * category[studyType]
   * ^short = "The way of grouping of the test results into clinically meaningful domains (e.g. hematology study, microbiology study, etc.)"
@@ -65,7 +62,6 @@ RuleSet: ReportCategoryRule
 // "The way of grouping of the test results into clinically meaningful domains (e.g. hematology study, microbiology study, etc.)"
 
 * category contains specialty 0..*
-* category[specialty] only $CodeableConcept-uv-ips
 * category[specialty] from LabSpecialtyEuVs
 * category[specialty]
   * ^short = "The clinical domain of the laboratory performing the observation (e.g. microbiology, toxicology, chemistry)"


### PR DESCRIPTION
This pull request primarily removes the use of the `$CodeableConcept-uv-ips` alias and related IPS profile aliases from multiple FSH files, and updates the references to use local or EU-specific profiles instead. This streamlines the codebase by reducing external dependencies and clarifies the use of value sets and profiles specific to the EU laboratory context. Additionally, some profile descriptions and documentation are improved for clarity.

Key changes include:

### Removal of IPS Profile Aliases and References

* Deleted all `$CodeableConcept-uv-ips` and other IPS profile aliases from `alias-lab.fsh`, eliminating their usage throughout the codebase.
* Removed constraints like `only $CodeableConcept-uv-ips` from `composition-lab.fsh`, `diagnosticReport-lab.fsh`, `observation-lab.fsh`, and common rulesets, shifting to local value sets or profiles instead. [[1]](diffhunk://#diff-4a62dde3c92aaadc1d98455798e604fd3a11a136c0075b6ec8e1457115f626c5L90-L92) [[2]](diffhunk://#diff-4a62dde3c92aaadc1d98455798e604fd3a11a136c0075b6ec8e1457115f626c5L115-L122) [[3]](diffhunk://#diff-05b3268afbb0328eeb36fc70a69fc3f2e9b6fb9809008ceb7fb1283543400f4dL52) [[4]](diffhunk://#diff-034fe20218cd96e198f91595b5740403b1dde46a0e07f6dbff1407f6d59bf516L34-R34) [[5]](diffhunk://#diff-034fe20218cd96e198f91595b5740403b1dde46a0e07f6dbff1407f6d59bf516L44-L51) [[6]](diffhunk://#diff-034fe20218cd96e198f91595b5740403b1dde46a0e07f6dbff1407f6d59bf516L61-L65) [[7]](diffhunk://#diff-034fe20218cd96e198f91595b5740403b1dde46a0e07f6dbff1407f6d59bf516L77) [[8]](diffhunk://#diff-1784751f54c97e5cbf24122e9c0320596ec2d5f9759ee244dbc39ca93a4fedadL68) [[9]](diffhunk://#diff-fedf6a186850feecdec9dcab07e63dcf16f300e5060f5c82ef1110c96b64198bL40) [[10]](diffhunk://#diff-fedf6a186850feecdec9dcab07e63dcf16f300e5060f5c82ef1110c96b64198bL52-L58) [[11]](diffhunk://#diff-fedf6a186850feecdec9dcab07e63dcf16f300e5060f5c82ef1110c96b64198bL68)

### Updates to Local Profile and Value Set Usage

* Updated `observation-results.fsh` to use `QuantityEuLab` and `RatioEuLab` instead of their IPS counterparts for `valueQuantity` and `valueRatio`.
* Ensured that category and code bindings reference EU-specific value sets (e.g., `LabStudyTypesEuVs`, `LabSpecialtyEuVs`, `LabReportTypesEuVs`, `LaboratoryResultStandardEuVs`) instead of IPS profiles. [[1]](diffhunk://#diff-034fe20218cd96e198f91595b5740403b1dde46a0e07f6dbff1407f6d59bf516L44-L51) [[2]](diffhunk://#diff-fedf6a186850feecdec9dcab07e63dcf16f300e5060f5c82ef1110c96b64198bL40) [[3]](diffhunk://#diff-fedf6a186850feecdec9dcab07e63dcf16f300e5060f5c82ef1110c96b64198bL52-L58) [[4]](diffhunk://#diff-fedf6a186850feecdec9dcab07e63dcf16f300e5060f5c82ef1110c96b64198bL68)

### Documentation and Description Improvements

* Enhanced the description for the `Quantity-eu-lab` profile to clarify the use of UCUM codes and the handling of textual units when no UCUM code is available.
* Minor formatting and comment clean-up in several profile and ruleset files. [[1]](diffhunk://#diff-722fe4532fdadeb3ce4b7af9570d9da3101a5a48c2f318aceef8b574e33bbd85L16) [[2]](diffhunk://#diff-722fe4532fdadeb3ce4b7af9570d9da3101a5a48c2f318aceef8b574e33bbd85L42)

These changes make the profiles and value sets more consistent with EU laboratory requirements and reduce reliance on the IPS (International Patient Summary) profiles.