### PR TITLE
Fhir 56314 missing data link

### DIFF
--- a/input/fsh/examples/lab_report/Specimen-animal.fsh
+++ b/input/fsh/examples/lab_report/Specimen-animal.fsh
@@ -8,7 +8,7 @@ Usage: #example
 * subject.extension[specimenAnimalSource].valueReference = Reference(Patient-animal-example)
 * collection.collectedDateTime = "2022-10-25T13:35:00+01:00"
 
-Instance: Patient-animal-example
+Instance: RelatedPerson-animal-example
 InstanceOf: AnimalSpecimenEuLab
 Usage: #example
 * extension[specimen-animal].valueCodeableConcept = $sct#448169003 "Domestic cat"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -185,6 +185,7 @@ menu:
     Challenges: challenges.html
     Design Choices: design-choice.html
     Certified reference material: crm.html
+    Handling Missing Data: https://hl7.eu/fhir/base/2.0.0/missing-data.html
   Functional:
     Scenarios: scenarios.html
     Managing statuses: status-mgmt.html
@@ -347,9 +348,9 @@ resources:
     name: "ServiceRequest: example"
     description: Example of ServiceRequest conforming this guide.
 
-  Patient/Patient-animal-example:
-    name: "Patient: animal example"
-    description: Example of Patient resource used for indicating an animal (cat) conforming this guide.
+  RelatedPerson/RelatedPerson-animal-example:
+    name: "RelatedPerson: animal example"
+    description: Example of RelatedPerson resource used for indicating an animal (cat) as the specimen source, conforming this guide.
 
   # -------------  Obligations
   StructureDefinition/Patient-obl-eu-lab:


### PR DESCRIPTION
This pull request updates the animal specimen example to use a `RelatedPerson` resource instead of a `Patient` resource for representing an animal as a specimen source. It also updates the documentation to reflect this change and adds a new external link for handling missing data.

Resource model update:

* Changed the animal specimen example from using a `Patient` resource (`Patient-animal-example`) to a `RelatedPerson` resource (`RelatedPerson-animal-example`) in both the FSH example (`Specimen-animal.fsh`) and the resource listings in `sushi-config.yaml`. This aligns the representation with the intended modeling of animals as specimen sources. [[1]](diffhunk://#diff-df67788a32b994377e55f6b47c4c794b69df4d2757a1f125d54be4f7904ce8aeL11-R11) [[2]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L350-R353)

Documentation improvements:

* Updated the description and references in `sushi-config.yaml` to reflect the use of `RelatedPerson` for animal examples, ensuring consistency in documentation and resource references.
* Added a new external documentation link for "Handling Missing Data" to the menu in `sushi-config.yaml`, providing users with additional guidance on this topic.