### PR TITLE
Fhir 55624

### DIFF
--- a/input/fsh/examples/lab_report/Specimen-animal.fsh
+++ b/input/fsh/examples/lab_report/Specimen-animal.fsh
@@ -5,7 +5,7 @@ Usage: #example
 * status = #available
 * type = $sct#119297000	"Blood specimen"
 * subject = Reference(pat-lab-example)
-* subject.extension[specimenAnimalSource].valueReference = Reference(Patient-animal-example)
+* subject.extension[specimenAnimalSource].valueReference = Reference(RelatedPerson-animal-example)
 * collection.collectedDateTime = "2022-10-25T13:35:00+01:00"
 
 Instance: RelatedPerson-animal-example

--- a/input/fsh/profiles/bundle-lab.fsh
+++ b/input/fsh/profiles/bundle-lab.fsh
@@ -1,46 +1,3 @@
-//===================================
-/// INVARIANTS
-//===================================
-
-Invariant: dr-comp-enc
-Description: "DiagnosticReport and Composition SHALL have the same encounter"
-/* Expression: "( (entry:composition.resource.encounter.empty() and entry:diagnosticReport.resource.encounter.empty() ) or entry:composition.resource.encounter = entry:diagnosticReport.resource.encounter )" */
-Expression: "( (entry.resource.ofType(Composition).encounter.empty() and entry.resource.ofType(DiagnosticReport).encounter.empty() ) or entry.resource.ofType(Composition).encounter = entry.resource.ofType(DiagnosticReport).encounter )"
-Severity:    #error
-
-Invariant: dr-comp-subj
-Description: "DiagnosticReport and Composition SHALL have the same subject"
-Expression: "( (entry.resource.ofType(Composition).subject.empty() and entry.resource.ofType(DiagnosticReport).subject.empty() ) or entry.resource.ofType(Composition).subject = entry.resource.ofType(DiagnosticReport).subject )"
-Severity:    #error
-
-
-Invariant: dr-comp-type
-Description: "At least one DiagnosticReport.code.coding and Composition.type.coding SHALL be equal"
-Expression: "entry.resource.ofType(Composition).type.coding.intersect(entry.resource.ofType(DiagnosticReport).code.coding).exists()"
-Severity:    #error
-
-Invariant: dr-comp-category
-Description: "At least one DiagnosticReport.category.coding and Composition.category.coding SHALL be equal"
-Expression: "(entry.resource.ofType(Composition).category.exists() or entry.resource.ofType(DiagnosticReport).category.exists()) implies entry.resource.ofType(Composition).category.coding.intersect(entry.resource.ofType(DiagnosticReport).category.coding).exists()"
-Severity:    #error
-
-Invariant: dr-comp-identifier
-Description: "If one or more DiagnosticReport.identifiers are given, at least one of them SHALL be equal to the Composition.identifier"
-/* "Composition.identifier SHALL be equal to one of DiagnosticReport.identifier, if at least one exists" */
-
-Expression: "(entry.resource.ofType(Composition).identifier.exists() or entry.resource.ofType(DiagnosticReport).identifier.exists()) implies entry.resource.ofType(Composition).identifier.intersect(entry.resource.ofType(DiagnosticReport).identifier).exists()"
-Severity:    #error
-
-Invariant: one-comp
-Description: "A laboratory report bundle SHALL include one and only one Composition"
-Expression: "entry.resource.ofType(Composition).count() = 1"
-Severity:    #error
-
-Invariant: one-dr
-Description: "A laboratory report SHALL include one and only one DiagnosticReport"
-Expression: "entry.resource.ofType(DiagnosticReport).count() = 1"
-Severity:    #error
-
 //==========================
 // PROFILE
 //==========================
@@ -50,8 +7,6 @@ Parent: Bundle
 Id: Bundle-eu-lab
 Title: "Bundle: Laboratory Report"
 Description: "Clinical document used to represent a Laboratory Report for the scope of the HL7 Europe project."
-// * ^publisher = "HL7 Europe"
-// * ^copyright = "HL7 Europe"
 * insert SetFmmandStatusRule ( 2, trial-use)
 * . ^short = "Laboratory Report bundle"
 * . ^definition = "Laboratory Report bundle."
@@ -82,7 +37,6 @@ Description: "Clinical document used to represent a Laboratory Report for the sc
 
 * entry ^slicing.discriminator[0].type = #type
 * entry ^slicing.discriminator[0].path = "resource"
-// * entry ^slicing.ordered = true => changed on 2023-07-19  to be checked
 * entry ^slicing.ordered = false
 * entry ^slicing.rules = #open
 
@@ -96,7 +50,7 @@ Description: "Clinical document used to represent a Laboratory Report for the sc
 * entry[patient].resource only Patient // or PatientEuCore or PatientAnimalEuCore changed based on https://jira.hl7.org/browse/FHIR-56181
 
 * entry contains observation 0..*
-* entry[observation].resource only Observation // ObservationResultsLaboratoryEu
+* entry[observation].resource only Observation // not only LaboratoryObservation as this might be needed for ServiceRequest.supportingInformation
 
 * entry contains specimen 0..*
 * entry[specimen].resource only SpecimenEu
@@ -146,6 +100,45 @@ Description: "Clinical document used to represent a Laboratory Report for the sc
 * entry contains medicationAdministration 0..*
 * entry[medicationAdministration].resource only MedicationAdministration
 
-//* entry contains documentReference 0..*
-//* entry[documentReference].resource only DocumentReference
+//===================================
+/// INVARIANTS
+//===================================
 
+Invariant: dr-comp-enc
+Description: "DiagnosticReport and Composition SHALL have the same encounter"
+/* Expression: "( (entry:composition.resource.encounter.empty() and entry:diagnosticReport.resource.encounter.empty() ) or entry:composition.resource.encounter = entry:diagnosticReport.resource.encounter )" */
+Expression: "( (entry.resource.ofType(Composition).encounter.empty() and entry.resource.ofType(DiagnosticReport).encounter.empty() ) or entry.resource.ofType(Composition).encounter = entry.resource.ofType(DiagnosticReport).encounter )"
+Severity:    #error
+
+Invariant: dr-comp-subj
+Description: "DiagnosticReport and Composition SHALL have the same subject"
+Expression: "( (entry.resource.ofType(Composition).subject.empty() and entry.resource.ofType(DiagnosticReport).subject.empty() ) or entry.resource.ofType(Composition).subject = entry.resource.ofType(DiagnosticReport).subject )"
+Severity:    #error
+
+
+Invariant: dr-comp-type
+Description: "At least one DiagnosticReport.code.coding and Composition.type.coding SHALL be equal"
+Expression: "entry.resource.ofType(Composition).type.coding.intersect(entry.resource.ofType(DiagnosticReport).code.coding).exists()"
+Severity:    #error
+
+Invariant: dr-comp-category
+Description: "At least one DiagnosticReport.category.coding and Composition.category.coding SHALL be equal"
+Expression: "(entry.resource.ofType(Composition).category.exists() or entry.resource.ofType(DiagnosticReport).category.exists()) implies entry.resource.ofType(Composition).category.coding.intersect(entry.resource.ofType(DiagnosticReport).category.coding).exists()"
+Severity:    #error
+
+Invariant: dr-comp-identifier
+Description: "If one or more DiagnosticReport.identifiers are given, at least one of them SHALL be equal to the Composition.identifier"
+/* "Composition.identifier SHALL be equal to one of DiagnosticReport.identifier, if at least one exists" */
+
+Expression: "(entry.resource.ofType(Composition).identifier.exists() or entry.resource.ofType(DiagnosticReport).identifier.exists()) implies entry.resource.ofType(Composition).identifier.intersect(entry.resource.ofType(DiagnosticReport).identifier).exists()"
+Severity:    #error
+
+Invariant: one-comp
+Description: "A laboratory report bundle SHALL include one and only one Composition"
+Expression: "entry.resource.ofType(Composition).count() = 1"
+Severity:    #error
+
+Invariant: one-dr
+Description: "A laboratory report SHALL include one and only one DiagnosticReport"
+Expression: "entry.resource.ofType(DiagnosticReport).count() = 1"
+Severity:    #error


### PR DESCRIPTION
This pull request reorganizes and updates the laboratory report bundle profile definitions to improve clarity and ensure correct validation logic. The main changes involve moving invariant definitions to a more appropriate location in the file, updating references to align with the latest FHIR guidance, and clarifying resource constraints in the bundle.

**Validation logic (Invariants):**
* Moved all invariant definitions (rules ensuring consistency between `Composition` and `DiagnosticReport` entries in the bundle) from the top of `bundle-lab.fsh` to the end of the file, grouping them after the main profile structure. This improves file organization and maintainability. [[1]](diffhunk://#diff-3f98fda87a2b0788f72d77f66b1d21314465eb753bce9c100bf80b1a396db4a8L1-L43) [[2]](diffhunk://#diff-3f98fda87a2b0788f72d77f66b1d21314465eb753bce9c100bf80b1a396db4a8L149-R144)

**Resource constraints and clarifications:**
* Updated the allowed resource type for `entry[observation].resource` to permit any `Observation`, not just laboratory-specific ones, to accommodate cases like `ServiceRequest.supportingInformation`.
* Added clarifying comments regarding the allowed patient resource types and removed outdated or commented publisher/copyright metadata.

**Slicing rules:**
* Explicitly set `entry ^slicing.ordered = false` to clarify that the order of sliced entries is not significant.

**Example updates:**
* In the specimen animal example, changed the reference for the animal source from a `Patient` to a `RelatedPerson`, aligning with the correct FHIR resource usage.