### PR TITLE
feat: add guidance on animal use cases in patient and specimen profiles

### DIFF
--- a/input/pagecontent/StructureDefinition-Patient-animal-eu-lab-intro.md
+++ b/input/pagecontent/StructureDefinition-Patient-animal-eu-lab-intro.md
@@ -1,0 +1,15 @@
+#### Implementation status
+
+<div class="dragon">
+
+  <p><strong>Implementation status</strong></p>
+  <p>
+    The profile <code>PatientAnimalEu</code>, and therefore the use case where the animal is the patient/subject of care, is currently blocked by a limitation in <code>hl7-base</code>.
+  </p>
+  <p>
+    At the moment, <code>hl7-base</code> allows only <code>PatientEuCore</code> as <code>subject</code>.
+  </p>
+  <p>
+    This limitation is expected to be resolved in a future version of <code>hl7-base</code>.
+  </p>
+</div>

--- a/input/pagecontent/StructureDefinition-Specimen-eu-lab-intro.md
+++ b/input/pagecontent/StructureDefinition-Specimen-eu-lab-intro.md
@@ -1,0 +1,22 @@
+#### Implementation note: animal as specimen source
+
+<div class="dragon">
+  <p>
+    Issue <a href="https://jira.hl7.org/browse/FHIR-53384">FHIR-53384</a> was discussed and agreed in the Orders and Observation Workgroup of HL7 International, voting on using <code>RelatedPerson</code> for representing the animal as the source of a <code>Specimen</code>.
+  </p>
+  <p>
+    This decision is currently being challenged, because with this approach the <code>Specimen</code> can no longer be assigned to the <code>Patient</code> compartment.
+  </p>
+  <p>
+    Issue <a href="https://jira.hl7.org/browse/FHIR-56301">FHIR-56301</a> therefore proposes introducing a new element <code>Specimen.focus</code> (analogous to <code>Observation.focus</code>).
+  </p>
+  <p>
+    For most use cases, especially when the animal does not need to be explicitly represented as an individual entity, <code>Specimen.type</code> SHALL be used with an appropriate SNOMED CT code (e.g. <code>710069003 | Tick specimen (specimen)</code>).
+  </p>
+  <p>
+    Explicit modeling of the animal itself is only relevant if the animal needs to be represented as a distinct entity (e.g. identifiable animal), or if no suitable SNOMED CT code exists to adequately pre-coordinate the specimen type.
+  </p>
+  <p>
+    How to represent the animal in such cases is currently still under discussion.
+  </p>
+</div>


### PR DESCRIPTION
This pull request adds important implementation notes and status updates regarding the representation of animals in laboratory-related FHIR profiles. The new content clarifies current limitations and ongoing discussions in the use of animals as patients or specimen sources.

Implementation status and limitations:

* Added a section to the `Patient-animal-eu-lab-intro.md` file documenting that the `PatientAnimalEu` profile is currently blocked by a limitation in `hl7-base`, which only allows `PatientEuCore` as a `subject`. This limitation is expected to be resolved in a future version.

Implementation guidance and ongoing discussions:

* Added a section to the `Specimen-eu-lab-intro.md` file summarizing the current status and debates around using `RelatedPerson` for representing animals as the source of a `Specimen`, the implications for compartment assignment, and the proposal to introduce a new `Specimen.focus` element. The note also provides guidance on when to use SNOMED CT codes in `Specimen.type` and highlights that explicit modeling of animals is only needed in specific scenarios.