### PR TITLE
fix: fix eu-lab-1 and eu-lab-2 invariants and expressions to also pay attention to r5 valueAttachment Extensions FHIR-56821

### DIFF
--- a/input/fsh/examples/lab_report/Observation-invariant-extension-examples.fsh
+++ b/input/fsh/examples/lab_report/Observation-invariant-extension-examples.fsh
@@ -1,0 +1,52 @@
+Instance: ObservationInvariantTopLevelValueExtension
+InstanceOf: ObservationResultsLaboratoryEu
+Title: "Observation: invariant test with top-level value extension"
+Description: "Positive invariant example: no value[x], but extension-Observation.value is present."
+Usage: #example
+
+* id = "a9d31b0d-a2e2-4dd8-95c3-1b99f6c13d11"
+* status = #final
+* category[laboratory] = $observation-category#laboratory
+* code = $loinc#24357-6 "Urinalysis macro (dipstick) panel - Urine"
+* subject = Reference(urn:uuid:de17bfd2-8d73-45fa-b0bb-8eb0e463ddb8)
+* effectiveDateTime = "2023-03-27T11:24:26+01:00"
+* performer[+].display = "Jan Laborant"
+* extension[+].url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value"
+* extension[=].valueAttachment
+  * contentType = #text/plain
+  * data = "Q2xvdWR5"
+
+Instance: ObservationInvariantComponentValueExtension
+InstanceOf: ObservationResultsLaboratoryEu
+Title: "Observation: invariant test with component value extension"
+Description: "Positive invariant example: component has no value[x], but extension-Observation.component.value is present."
+Usage: #example
+
+* id = "a84be3b7-c986-4fdf-9ec5-bbe5f7f8de9e"
+* status = #final
+* category[laboratory] = $observation-category#laboratory
+* code = $loinc#24357-6 "Urinalysis macro (dipstick) panel - Urine"
+* subject = Reference(urn:uuid:de17bfd2-8d73-45fa-b0bb-8eb0e463ddb8)
+* effectiveDateTime = "2023-03-27T11:24:26+01:00"
+* performer[+].display = "Jan Laborant"
+* component[+].code = $loinc#5778-6 "Color of Urine"
+* component[=].extension[+].url = "http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.component.value"
+* component[=].extension[=].valueAttachment
+  * contentType = #text/plain
+  * data = "QW1iZXI="
+
+Instance: ObservationInvariantComponentValueDataAbsentReason
+InstanceOf: ObservationResultsLaboratoryEu
+Title: "Observation: invariant test with component dataAbsentReason"
+Description: "Positive invariant example: component has no value[x], but component.dataAbsentReason is present."
+Usage: #example
+
+* id = "60e4df2e-0a92-4474-8e24-27de6bc0e654"
+* status = #final
+* category[laboratory] = $observation-category#laboratory
+* code = $loinc#24357-6 "Urinalysis macro (dipstick) panel - Urine"
+* subject = Reference(urn:uuid:de17bfd2-8d73-45fa-b0bb-8eb0e463ddb8)
+* effectiveDateTime = "2023-03-27T11:24:26+01:00"
+* performer[+].display = "Jan Laborant"
+* component[+].code = $loinc#5778-6 "Color of Urine"
+* component[=].dataAbsentReason = $data-absent-reason#unknown

--- a/input/fsh/profiles/bundle-lab.fsh
+++ b/input/fsh/profiles/bundle-lab.fsh
@@ -107,22 +107,27 @@ Description: "Clinical document used to represent a Laboratory Report for the sc
 Invariant: dr-comp-enc
 Description: "DiagnosticReport and Composition SHALL have the same encounter"
 /* Expression: "( (entry:composition.resource.encounter.empty() and entry:diagnosticReport.resource.encounter.empty() ) or entry:composition.resource.encounter = entry:diagnosticReport.resource.encounter )" */
+// TODO: Consider comparing encounter.reference instead of the full Reference object. FHIRPath '=' compares complex objects structurally, so semantically equal references may fail if display, identifier, or reference style differs.
 Expression: "( (entry.resource.ofType(Composition).encounter.empty() and entry.resource.ofType(DiagnosticReport).encounter.empty() ) or entry.resource.ofType(Composition).encounter = entry.resource.ofType(DiagnosticReport).encounter )"
 Severity:    #error
 
 Invariant: dr-comp-subj
 Description: "DiagnosticReport and Composition SHALL have the same subject"
+// TODO: Consider comparing subject.reference instead of the full Reference object. FHIRPath '=' compares complex objects structurally, so semantically equal references may fail if display, identifier, or reference style differs.
 Expression: "( (entry.resource.ofType(Composition).subject.empty() and entry.resource.ofType(DiagnosticReport).subject.empty() ) or entry.resource.ofType(Composition).subject = entry.resource.ofType(DiagnosticReport).subject )"
 Severity:    #error
 
 
 Invariant: dr-comp-type
 Description: "At least one DiagnosticReport.code.coding and Composition.type.coding SHALL be equal"
+// TODO: intersect() compares complete Coding elements. This may be too strict if system and code match but display or version differ; consider comparing system + code explicitly.
 Expression: "entry.resource.ofType(Composition).type.coding.intersect(entry.resource.ofType(DiagnosticReport).code.coding).exists()"
 Severity:    #error
 
 Invariant: dr-comp-category
 Description: "At least one DiagnosticReport.category.coding and Composition.category.coding SHALL be equal"
+// TODO: Check whether the implication should use 'and' instead of 'or'. With 'or', the invariant fails when only one side has category, because no intersection is possible.
+// TODO: intersect() compares complete Coding elements. This may be too strict if system and code match but display or version differ; consider comparing system + code explicitly.
 Expression: "(entry.resource.ofType(Composition).category.exists() or entry.resource.ofType(DiagnosticReport).category.exists()) implies entry.resource.ofType(Composition).category.coding.intersect(entry.resource.ofType(DiagnosticReport).category.coding).exists()"
 Severity:    #error
 
@@ -130,6 +135,8 @@ Invariant: dr-comp-identifier
 Description: "If one or more DiagnosticReport.identifiers are given, at least one of them SHALL be equal to the Composition.identifier"
 /* "Composition.identifier SHALL be equal to one of DiagnosticReport.identifier, if at least one exists" */
 
+// TODO: The description only mentions DiagnosticReport.identifier, but the expression also triggers when only Composition.identifier exists. Consider using DiagnosticReport.identifier.exists() as the implication condition.
+// TODO: intersect() compares complete Identifier elements. This may be too strict if system and value match but assigner, type, period, or use differ; consider comparing system + value explicitly.
 Expression: "(entry.resource.ofType(Composition).identifier.exists() or entry.resource.ofType(DiagnosticReport).identifier.exists()) implies entry.resource.ofType(Composition).identifier.intersect(entry.resource.ofType(DiagnosticReport).identifier).exists()"
 Severity:    #error
 

--- a/input/fsh/profiles/observation-lab.fsh
+++ b/input/fsh/profiles/observation-lab.fsh
@@ -73,12 +73,14 @@ That's why it is important to explicitly include informaiton about measurement m
   * code from LaboratoryResultStandardEuVs (preferred)
   * insert ObservationResultsValueEu
 
+//TODO: use hasValue in next release
+
 Invariant: eu-lab-1
 Description: "If observation status is other then \"registered\" or \"cancelled\", at least one of these Observation elements shall be provided:  \"value\", \"dataAbsentReason\", \"hasMember\" or \"component\""
 Severity: #error
-Expression: "(status in ('registered'|'cancelled')) or value.exists() or hasMember.exists() or component.exists() or dataAbsentReason.exists()"
+Expression: "(status in ('registered'|'cancelled')) or value.exists() or extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value').exists() or hasMember.exists() or component.exists() or dataAbsentReason.exists()"
 
 Invariant: eu-lab-2
 Description: "If observation has components and observation status is other then \"registered\" or \"cancelled\", at least one of these Observation.component elements shall be provided:  \"value\" or \"dataAbsentReason\""
 Severity: #error
-Expression: "component.exists() implies (status in ('registered'|'cancelled')) or component.value.exists() or component.dataAbsentReason.exists()"
+Expression: "component.exists() implies (status in ('registered'|'cancelled')) or component.value.exists() or component.extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.component.value').exists() or component.dataAbsentReason.exists()"

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -92,3 +92,6 @@ Wrong Display Name 'Turkey' for http://snomed.info/sct#425134008. Valid display 
 
 # Duplicated anchors added by the template
 The html source has duplicate anchor Ids: 1
+
+# == Base uses the wrong valueR5 extension on component, filtering the warning for the example, to be removed after base is fixed
+This element does not match any known slice defined in the profile http://hl7.eu/fhir/laboratory/StructureDefinition/Observation-resultslab-eu-lab|2.0.0 (this may not be a problem, but you should check that it's not intended to match a slice)


### PR DESCRIPTION
This pull request introduces several improvements and clarifications related to FHIR invariants for laboratory observations and bundles, as well as new example instances and enhanced documentation. The main focus is on ensuring that invariants correctly handle value extensions, adding positive test examples, and documenting potential pitfalls with FHIRPath expressions.

**Invariant logic and documentation improvements:**

* Updated the `eu-lab-1` and `eu-lab-2` invariants in `observation-lab.fsh` to explicitly allow the use of value extensions (`extension-Observation.value` and `extension-Observation.component.value`) in addition to standard value fields. This ensures that observations using these extensions are valid per the profile.
* Added TODO comments to bundle-level invariants in `bundle-lab.fsh` explaining potential issues with FHIRPath equality and intersection semantics, such as comparing complex objects structurally and the strictness of `intersect()` on codings and identifiers. This will help future maintainers understand and potentially improve the logic.

**Examples and test data:**

* Added three new example instances in `Observation-invariant-extension-examples.fsh` to demonstrate positive cases where value extensions or `dataAbsentReason` are used in place of standard value fields, supporting the updated invariants.

**Build and warning handling:**

* Added a temporary filter to `ignoreWarnings.txt` to suppress a known warning about the use of a valueR5 extension on a component in example data, pending a fix in the base profile.