### PR TITLE
feat: remove Composition.section:attachment and update guidance for DiagnosticReport.media

### DIFF
--- a/input/fsh/profiles/composition-lab.fsh
+++ b/input/fsh/profiles/composition-lab.fsh
@@ -83,18 +83,7 @@ Technical note: A list of accredited examination(s) is available at www.laborato
   * entry 0..0
   * section 0..0
 
-
 // -------------------------------------
-// Attachment section  0 .. 1
+// Attachment section removed based on the resolution of the Jira issue FHIR-53138
+// Additional data associated with the report is conveyed through DiagnosticReport.media
 // -------------------------------------
-
-
-* section contains attachment ..* // check if ..1 or ..*
-* section[attachment]
-  * ^short = "Additional data (like images, diagrams) associated with this report"
-  * ^definition = """A  list of additional data associated with this report. This data is generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest)."""
-
-  * code = $loinc#77599-9
-  * entry 1..
-  * entry only Reference (Binary or DocumentReference)
-  * section 0..0

--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -72,8 +72,8 @@ Commented based on the suggestion form the 2023-05-26 meeting see https://github
 * presentedForm ^short = "Entire report as issued (pdf recommended)"
 // TODO: is using docref instead of media relevant for the base spec?
 * media
-  * ^short = "Additional data (like images, diagrams or documents) associated with this report"
-  * ^definition = "A list of additional data, other then presented form of the report, associated with this report. This data is generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest)."
+  * ^short = "Additional data (like images, diagrams) associated with this report"
+  * ^definition = "A list of additional data associated with this report. This data is generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest)."
   * ^requirements = "Some diagnostic reports may include additional data such as images, diagrams or documents that are relevant to the report. This additional information can provide further context and support for the findings presented in the report."
   * ^alias = "DICOM; Slides; Scans; Pictures; Documents; Diagrams"
   * comment

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,6 +1,11 @@
 This page summarizes the main changes applied to this version of the guide.
 
 
+### From 2.0.0 to 2.0.1
+
+* Removed the `Composition.section:attachment` slice and added guidance on `DiagnosticReport.media` for additional data associated with the report (FHIR-53138).
+* Updated the `eu-lab-1` and `eu-lab-2` invariants to explicitly support the R5 `value[x]` and `component.value[x]` extensions, and added examples covering all valid ways a laboratory result value may be expressed (FHIR-56821).
+
 ### From 0.1.1 to 2.0.0
 
 #### 🔧 Model Alignment and Refactoring


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-57444

This pull request updates the laboratory reporting profiles to align with recent guidance and resolves key Jira issues. The most significant change is the removal of the `Composition.section:attachment` slice, with additional data now conveyed through `DiagnosticReport.media`. Definitions and guidance around `media` have also been clarified.

**Profile and Structure Updates:**

* Removed the `Composition.section:attachment` slice from `composition-lab.fsh` based on the resolution of Jira issue FHIR-53138, with guidance to use `DiagnosticReport.media` for additional data such as images or diagrams.
* Updated the definition and short description of the `media` field in `diagnosticReport-lab.fsh` to clarify its use for additional data associated with the report.

**Documentation:**

* Added a summary of these changes to `changes.md`, including explicit reference to the removal of the attachment section and guidance on using `DiagnosticReport.media` (FHIR-53138).