### PR TITLE
feat: update Specimen profile to relax type cardinality

### DIFF
--- a/input/fsh/profiles/specimen-lab.fsh
+++ b/input/fsh/profiles/specimen-lab.fsh
@@ -12,7 +12,6 @@ Description: """This profile defines how to represent Specimens in HL7 FHIR for 
 * extension[focus] ^short = "Animal specimen source"
 // TODO: add biological derived product?
 * subject only Reference (PatientEuCore or Group or Device or Substance or Location)
-* type 1..1
 * type from LabSpecimenTypesEuVs (preferred)
   * ^comment = """If the specimen.type conveys information about the site the specimen has been collected from, then, if the bodySite if present it shall be coherent with the type.
 For a non-identifiable animal specimen source (e.g. 710069003 | Tick specimen (specimen) |), Specimen.type with the appropriate code shall be used."""


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-57895

This pull request makes a minor adjustment to the `specimen-lab.fsh` profile by removing the requirement that the `type` field must always be present. This change allows for more flexibility in representing specimens.