### PR TITLE
TC: align Specimen.container.device extension cardinality with its definition

### DIFF
--- a/input/fsh/examples/lab_report/Specimen-container-device-example.fsh
+++ b/input/fsh/examples/lab_report/Specimen-container-device-example.fsh
@@ -1,0 +1,28 @@
+Instance: Specimen-container-device-example
+InstanceOf: SpecimenEu
+Title: "Specimen: container device example"
+Description: "Example of a blood specimen collected into an evacuated blood collection tube. The container is described by a Device resource, referenced through the R5 `Specimen.container.device` extension."
+Usage: #example
+
+* contained = BloodCollectionTubeExample
+* status = #available
+* type = $sct#119297000 "Blood specimen"
+* subject = Reference(pat-lab-example)
+* collection.collectedDateTime = "2025-04-08T08:15:00+02:00"
+* container
+  * identifier.system = "http://example.org/specimen-containers"
+  * identifier.value = "TUBE-0000123"
+  * type = $sct#702281005 "Evacuated blood collection tube, thrombin/clot activator/gel separator"
+  * extension[device].valueReference = Reference(BloodCollectionTubeExample)
+
+Instance: BloodCollectionTubeExample
+InstanceOf: Device
+Title: "Device: blood collection tube example"
+Description: "Example of the device representing the container the specimen is held in."
+Usage: #inline
+* type = $sct#702281005 "Evacuated blood collection tube, thrombin/clot activator/gel separator"
+* deviceName
+  * name = "BEST® Serum Separator Tube 5 mL"
+  * type = #manufacturer-name
+* manufacturer = "Best manufacturer"
+* lotNumber = "L20250312A"

--- a/input/fsh/profiles/specimen-lab.fsh
+++ b/input/fsh/profiles/specimen-lab.fsh
@@ -33,7 +33,7 @@ Otherwise the relationship is recorded in the Specimen.request element"""
 * container
   * type from LabSpecimenContainerEu (preferred)
   * additive[x] 0..0
-  * extension contains $specimen-container-device-r5 named device 0..1
+  * extension contains $specimen-container-device-r5 named device 1..1
   * extension[device].valueReference only Reference(Device)
 
 // ----------------------------------------

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -4,6 +4,7 @@ This page summarizes the main changes applied to this version of the guide.
 ### From 2.0.0 to 2.0.1
 
 * Removed the `Composition.section:attachment` slice and added guidance on `DiagnosticReport.media` for additional data associated with the report (FHIR-53138).
+* Aligned the cardinality of the `Specimen.container.device` R5 cross-version extension with its definition (`1..1`) and added an example using it (FHIR-58773).
 * Updated the `eu-lab-1` and `eu-lab-2` invariants to explicitly support the R5 `value[x]` and `component.value[x]` extensions, and added examples covering all valid ways a laboratory result value may be expressed (FHIR-56821).
 
 ### From 0.1.1 to 2.0.0

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -322,6 +322,10 @@ resources:
     name: "Specimen: animal example"
     description: Example of Specimen collected from an animal.
 
+  Specimen/Specimen-container-device-example:
+    name: "Specimen: container device example"
+    description: Example of Specimen whose container is described by a Device resource, referenced through the R5 `Specimen.container.device` extension.
+
   DiagnosticReport/dr-lab-example:
     name: "DiagnosticReport: example"
     description: Example of DiagnosticReport conforming this guide.


### PR DESCRIPTION
TC: https://jira.hl7.org/browse/FHIR-58773

The R5 cross-version extension `http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.container.device` defines its root element as `1..1`, derived from the R5 source element `Specimen.container.device 1..1 Reference(Device)`. The Specimen profile constrained the slice to `0..1`.

The mismatch is never reported by any tooling: SUSHI validates the `contains` cardinality only against the base element `Specimen.container.extension` (`0..*`), the snapshot generator takes min/max from the differential slice, and the validator evaluates an extension definition only when an extension instance is actually present. `Specimen.container.device` is also the only cross-version extension used in this guide whose root is `1..1`.

**Changes**

- `Specimen.container.extension:device` set to `1..1`, matching the extension definition. `Specimen.container` itself stays `0..*`, so the constraint applies only when a container is present.
- Added `Specimen-container-device-example`: a blood specimen collected into an evacuated blood collection tube, where the container is described by a contained `Device` resource referenced through the extension. Registered in `sushi-config.yaml`.
- Changelog entry under 2.0.1.

SUSHI runs with 0 errors and 0 warnings.
