### PR TITLE
TC: remove additional bindings on valueCodeableConcept

### DIFF
--- a/input/fsh/rulesSet/observation-results.fsh
+++ b/input/fsh/rulesSet/observation-results.fsh
@@ -21,33 +21,9 @@ RuleSet: ObservationResultsValueEu
 * valuePeriod ^sliceName = "valuePeriod"
 * valueQuantity only QuantityEuLab
 * valueQuantity ^sliceName = "valueQuantity"
+// The additional bindings have been removed based on the resolution of the Jira issue FHIR-57048:
+// the blood group, presence/absence and microorganism value sets they pointed to are already
+// part of the value set bound above, which is composed of the IPS blood group, presence/absence,
+// microorganism and pathology value sets.
 * valueCodeableConcept from $results-coded-values-laboratory-pathology-uv-ips (preferred)
-//TODO: do we need this slicing?
 * valueCodeableConcept ^sliceName = "valueCodeableConcept"
-* valueCodeableConcept ^binding.extension[0].extension[0].url = "purpose"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueCode = #candidate
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "valueSet"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueCanonical = "http://hl7.org/fhir/uv/ips/ValueSet/results-blood-group-snomed-ct-ips-free-set"
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "documentation"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueMarkdown = "Additional conformance binding to a blood group findings value set for laboratory result values from the SNOMED CT IPS free set for use globally (in SNOMED member and non-member jurisdictions)."
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "key"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueId = "lab-blood-group"
-* valueCodeableConcept ^binding.extension[=].url = "http://hl7.org/fhir/tools/StructureDefinition/additional-binding"
-* valueCodeableConcept ^binding.extension[+].extension[0].url = "purpose"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueCode = #preferred
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "valueSet"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueCanonical = Canonical(LabPresenceAbsenceEuVs)
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "documentation"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueMarkdown = "Additional conformance binding to a presence and absence findings (qualifier values) value set for laboratory result values, aligned with the eHDSI PresenceAbsence value set adopted by the eEHMSEG."
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "key"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueId = "lab-presence-absence"
-* valueCodeableConcept ^binding.extension[=].url = "http://hl7.org/fhir/tools/StructureDefinition/additional-binding"
-* valueCodeableConcept ^binding.extension[+].extension[0].url = "purpose"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueCode = #candidate
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "valueSet"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueCanonical = "http://hl7.org/fhir/uv/ips/ValueSet/results-microorganism-snomed-ct-ips-free-set"
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "documentation"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueMarkdown = "Additional conformance binding to a microorganisms value set for laboratory result values from the SNOMED CT IPS free set for use globally (in SNOMED member and non-member jurisdictions)."
-* valueCodeableConcept ^binding.extension[=].extension[+].url = "key"
-* valueCodeableConcept ^binding.extension[=].extension[=].valueId = "lab-microorganism"
-* valueCodeableConcept ^binding.extension[=].url = "http://hl7.org/fhir/tools/StructureDefinition/additional-binding"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -4,6 +4,7 @@ This page summarizes the main changes applied to this version of the guide.
 ### From 2.0.0 to 2.0.1
 
 * Removed the `Composition.section:attachment` slice and added guidance on `DiagnosticReport.media` for additional data associated with the report (FHIR-53138).
+* Removed the additional bindings on `Observation.value[x]:valueCodeableConcept` and `Observation.component.value[x]:valueCodeableConcept`, as the blood group, presence/absence and microorganism value sets are already part of the value set bound to the element (FHIR-57048).
 * Aligned the cardinality of the `Specimen.container.device` R5 cross-version extension with its definition (`1..1`) and added an example using it (FHIR-58773).
 * Updated the `eu-lab-1` and `eu-lab-2` invariants to explicitly support the R5 `value[x]` and `component.value[x]` extensions, and added examples covering all valid ways a laboratory result value may be expressed (FHIR-56821).
 


### PR DESCRIPTION
TC: https://jira.hl7.org/browse/FHIR-57048

The `valueCodeableConcept` slice in the `ObservationResultsValueEu` rule set carried three additional bindings:

| purpose | value set | key |
|---|---|---|
| candidate | `results-blood-group-snomed-ct-ips-free-set` | `lab-blood-group` |
| preferred | `LabPresenceAbsenceEuVs` | `lab-presence-absence` |
| candidate | `results-microorganism-snomed-ct-ips-free-set` | `lab-microorganism` |

The value set bound to the element, `results-coded-values-laboratory-pathology-uv-ips`, is composed of the IPS blood group, presence/absence, microorganism and pathology value sets — so the additional bindings covered ground the basic binding already covers.

**Changes**

- Removed the three additional bindings; the preferred binding to `results-coded-values-laboratory-pathology-uv-ips` stays. The rule set applies to both `Observation.value[x]:valueCodeableConcept` and `Observation.component.value[x]:valueCodeableConcept`, both are cleaned up.
- Changelog entry under 2.0.1.

`LabPresenceAbsenceEuVs` is no longer referenced by any profile after this change. It is still published as an artifact; removing it would be a separate decision.

SUSHI runs with 0 errors and 0 warnings.
