### PR TITLE
feat: add low and high comparator extensions for Observation.referenceRange

### DIFF
--- a/input/fsh/alias-systems.fsh
+++ b/input/fsh/alias-systems.fsh
@@ -22,6 +22,7 @@ Alias: $obligation-cs = http://hl7.org/fhir/CodeSystem/obligation
 Alias: $observation-category = http://terminology.hl7.org/CodeSystem/observation-category
 Alias: $orpha = https://www.orpha.net // Used urn:oid:1.3.6.1.4.1.12559.11.10.1.3.1.44.5 for the MyHealth@EU lab guide to be checked <====
 Alias: $pei = http://pei.de
+Alias: $quantity-comparator = http://hl7.org/fhir/quantity-comparator
 Alias: $referencerange-meaning = http://terminology.hl7.org/CodeSystem/referencerange-meaning
 Alias: $sct = http://snomed.info/sct
 Alias: $sex-parameter-for-clinical-use = http://terminology.hl7.org/CodeSystem/sex-parameter-for-clinical-use

--- a/input/fsh/examples/lab_report/Bundle-SimpleChemistryReport.fsh
+++ b/input/fsh/examples/lab_report/Bundle-SimpleChemistryReport.fsh
@@ -457,8 +457,10 @@ Usage: #inline
 * specimen = Reference(urn:uuid:5837e9bf-8a2b-43c3-bec8-d68dbd7fa7fb)  // urine specimen
 * referenceRange.low.value = 67
 * referenceRange.low.unit = "mmol/L"
+* referenceRange.modifierExtension[lowComparator].valueCode = #>
 * referenceRange.high.value = 580
 * referenceRange.high.unit = "mmol/L"
+* referenceRange.modifierExtension[highComparator].valueCode = #<
 * referenceRange.type = $referencerange-meaning#normal "Normal Range"
 
 Instance: Inline-Instance-for-Observation-18bd102e-0abf-42b0-b4e6-97e47fd385eb

--- a/input/fsh/extensions/extensions-lab.fsh
+++ b/input/fsh/extensions/extensions-lab.fsh
@@ -52,3 +52,41 @@ Description: "Specimen focus, Extension to represent the entity from which the s
 * insert ExtensionContext(Specimen)
 * insert SetFmmandStatusRule ( 2, trial-use)
 * value[x] only Reference(RelatedPerson or Group or Device or Substance or Location)
+
+ValueSet: ReferenceRangeLowComparator
+Id: reference-range-low-comparator
+Title: "Reference Range Low Comparator"
+Description: "Comparators permitted for the low bound of an Observation reference range."
+* $quantity-comparator#>= "Greater or Equal to"
+* $quantity-comparator#> "Greater than"
+
+ValueSet: ReferenceRangeHighComparator
+Id: reference-range-high-comparator
+Title: "Reference Range High Comparator"
+Description: "Comparators permitted for the high bound of an Observation reference range."
+* $quantity-comparator#<= "Less or Equal to"
+* $quantity-comparator#< "Less than"
+
+Extension: ObservationReferenceRangeLowComparator
+Id: observation-reference-range-low-comparator
+Title: "Observation Reference Range Low Comparator"
+Description: "The comparator for Observation.referenceRange.low. This modifier extension pre-adopts the R6 comparator on the low reference-range bound."
+* insert ExtensionContext(Observation.referenceRange)
+* insert SetFmmandStatusRule ( 2, trial-use)
+* . ^isModifier = true
+* . ^isModifierReason = "Changes the interpretation of Observation.referenceRange.low by stating whether the bound is inclusive or exclusive."
+* value[x] only code
+* valueCode 1..1
+* valueCode from ReferenceRangeLowComparator (required)
+
+Extension: ObservationReferenceRangeHighComparator
+Id: observation-reference-range-high-comparator
+Title: "Observation Reference Range High Comparator"
+Description: "The comparator for Observation.referenceRange.high. This modifier extension pre-adopts the R6 comparator on the high reference-range bound."
+* insert ExtensionContext(Observation.referenceRange)
+* insert SetFmmandStatusRule ( 2, trial-use)
+* . ^isModifier = true
+* . ^isModifierReason = "Changes the interpretation of Observation.referenceRange.high by stating whether the bound is inclusive or exclusive."
+* value[x] only code
+* valueCode 1..1
+* valueCode from ReferenceRangeHighComparator (required)

--- a/input/fsh/profiles/observation-lab.fsh
+++ b/input/fsh/profiles/observation-lab.fsh
@@ -30,6 +30,11 @@ This observation may represent the result of a simple laboratory test such as he
 
 * status ^short = "Status of this observation (e.g. preliminary, final,...)"
 
+* referenceRange.modifierExtension contains
+  ObservationReferenceRangeLowComparator named lowComparator 0..1 and
+  ObservationReferenceRangeHighComparator named highComparator 0..1
+* referenceRange ^comment = "Reference-range bounds are inclusive when no comparator is present. Use lowComparator or highComparator to state the comparator for an exclusive or explicitly inclusive bound. These modifier extensions pre-adopt the comparator on the reference-range bounds introduced in FHIR R6."
+
 * category 1..*
 * category
   * insert SliceElement (#pattern, $this)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -7,6 +7,7 @@ This page summarizes the main changes applied to this version of the guide.
 * Removed the additional bindings on `Observation.value[x]:valueCodeableConcept` and `Observation.component.value[x]:valueCodeableConcept`, as the blood group, presence/absence and microorganism value sets are already part of the value set bound to the element (FHIR-57048).
 * Aligned the cardinality of the `Specimen.container.device` R5 cross-version extension with its definition (`1..1`) and added an example using it (FHIR-58773).
 * Updated the `eu-lab-1` and `eu-lab-2` invariants to explicitly support the R5 `value[x]` and `component.value[x]` extensions, and added examples covering all valid ways a laboratory result value may be expressed (FHIR-56821).
+* Added optional `lowComparator` and `highComparator` modifier extensions for exclusive or explicitly inclusive `Observation.referenceRange` bounds, pre-adopting the FHIR R6 solution (FHIR-55966).
 
 ### From 0.1.1 to 2.0.0
 

--- a/input/pagecontent/notes.md
+++ b/input/pagecontent/notes.md
@@ -8,6 +8,12 @@ The current version of the HL7 Europe Laboratory Report Implementation Guide des
 
 An optional R5 extension of the observation (Observation.triggeredBy-r5) has been pre-adopted in the current version of the HL7 Europe Laboratory Report Implementation Guide. We recommend to use this extension for implementation of the so-called reflex tests, i.e. additional test cases in which more than one test could be used to fulfil a given requirement (order or panel). In such case Observation.triggeredBy-r5.type should be set to #reflex.
 
+### Exclusive reference-range bounds
+
+FHIR R4 represents `Observation.referenceRange.low` and `Observation.referenceRange.high` as `SimpleQuantity`, which cannot carry a comparator. This guide pre-adopts the R6 solution through two modifier extensions on `Observation.referenceRange`: `lowComparator` and `highComparator`. Use `lowComparator` with `>` or `>=`, and `highComparator` with `<` or `<=`, when the reference-range bound must be explicitly stated. In particular, use `>` and `<` for exclusive bounds.
+
+This is a temporary R4 solution. FHIR R6 changes the reference-range bounds to `Quantity` and provides the comparator directly on `low` and `high`; implementations should transition to that native representation when adopting R6. These optional extensions have no associated obligations because EHDS does not mandate reference-range comparators.
+
 ### Representation of the microbiology tests
 
 Microbiology tests are often being performed in consecutive steps, e.g. cultivation, possible quantification and subsequent sensitivity testing to antibiotics. Each analytical step depends on the result of the previous step or steps. Current version of the HL7 Europe Laboratory Report Implementation Guide recommends to use Observation.hasMember reference to express causality of the tests performed by the laboratory as shown in the [Microbiology Culture + Susceptibility](Bundle-BundleLabResultMicroCultureSusc.html).


### PR DESCRIPTION
This pull request introduces support for explicitly specifying inclusive or exclusive reference range bounds in laboratory observations by pre-adopting the FHIR R6 comparator solution. It adds new modifier extensions (`lowComparator` and `highComparator`) to `Observation.referenceRange`, updates the implementation guide documentation, and provides supporting value sets and example usage.

**Support for reference range comparators:**

* Added two modifier extensions, `ObservationReferenceRangeLowComparator` and `ObservationReferenceRangeHighComparator`, to `Observation.referenceRange` for specifying comparators (`>`, `>=`, `<`, `<=`) on the low and high bounds, respectively. These extensions are marked as modifiers and reference newly defined value sets. [[1]](diffhunk://#diff-38e0d071d672040e0a6787cc6e0ef1980fb086a3eda864f228b905deab5d7653R55-R92) [[2]](diffhunk://#diff-034fe20218cd96e198f91595b5740403b1dde46a0e07f6dbff1407f6d59bf516R33-R37)
* Created value sets `ReferenceRangeLowComparator` and `ReferenceRangeHighComparator` to restrict allowed comparator codes for the low and high bounds.
* Registered the `$quantity-comparator` alias for the FHIR Quantity Comparator code system.
* Updated the example lab report (`Bundle-SimpleChemistryReport.fsh`) to demonstrate use of the new comparator extensions.

**Documentation updates:**

* Added a summary of the new comparator extensions to the changelog (`changes.md`).
* Provided implementation guidance and rationale for the pre-adopted solution in the notes section (`notes.md`).