### PR TITLE
feat: enhance guidance for ServiceRequest.supportingInfo resource types

### DIFF
--- a/input/fsh/profiles/serviceRequest-lab.fsh
+++ b/input/fsh/profiles/serviceRequest-lab.fsh
@@ -24,5 +24,5 @@ If the ServiceRequest can be updated when the specimen is collected then the Ser
 Otherwise the relationship is recorded in the Specimen.request element"""
   // add invariant ?
 * insurance only Reference (Coverage)
-* supportingInfo ^short = "Additional information: e.g AOEs and prior results"
+* supportingInfo ^short = "Additional information: e.g AOEs and prior results. Most common resource types expected are: Observation, Condition, QuestionnaireResponse, MedicationStatement, MedicationRequest."
 * authoredOn ^short = "When the order was placed"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -8,6 +8,7 @@ This page summarizes the main changes applied to this version of the guide.
 * Aligned the cardinality of the `Specimen.container.device` R5 cross-version extension with its definition (`1..1`) and added an example using it (FHIR-58773).
 * Updated the `eu-lab-1` and `eu-lab-2` invariants to explicitly support the R5 `value[x]` and `component.value[x]` extensions, and added examples covering all valid ways a laboratory result value may be expressed (FHIR-56821).
 * Added optional `lowComparator` and `highComparator` modifier extensions for exclusive or explicitly inclusive `Observation.referenceRange` bounds, pre-adopting the FHIR R6 solution (FHIR-55966).
+* Added guidance on the most common resource types expected in `ServiceRequest.supportingInfo`, while keeping its target resource types open (FHIR-56397).
 
 ### From 0.1.1 to 2.0.0
 


### PR DESCRIPTION
This pull request provides additional guidance on the expected resource types for the `supportingInfo` field in `ServiceRequest`, clarifying documentation and improving implementer understanding.

Documentation improvements:

* Updated the `supportingInfo` field description in `serviceRequest-lab.fsh` to mention the most common expected resource types: `Observation`, `Condition`, `QuestionnaireResponse`, `MedicationStatement`, and `MedicationRequest`.
* Added a note in `changes.md` summarizing the new guidance on expected resource types for `ServiceRequest.supportingInfo`, while emphasizing that the field remains open to other resource types.