### PR TITLE
FHIR-57043: move Laboratory Accredited extension to the Extensions IG

### DIFF
--- a/input/fsh/extensions/extensions-lab.fsh
+++ b/input/fsh/extensions/extensions-lab.fsh
@@ -31,18 +31,8 @@ Description: """This extension links this observation with the laboratory test k
 * insert SetFmmandStatusRule ( 2, trial-use)
 * value[x] only Reference(Device)
 
-//TODO: will be moved to the extensions ig in the future. https://jira.hl7.org/browse/FHIR-56516
-Extension: LaboratoryAccreditedEu
-Id:   laboratory-accredited-eu
-Title:  "Laboratory Accredited"
-Description: """Simple accreditation extension.
-For Observation it indicates that the laboratory test was/is accredited.
-For ServiceRequest it indicates that the request shall be fulfilled by an accredited laboratory."""
-Context: Observation, ServiceRequest
-* ^url = "http://hl7.eu/fhir/StructureDefinition/laboratory-accredited"
-* insert SetFmmandStatusRule ( 2, trial-use)
-* value[x] only boolean
-* valueBoolean 1..1
+// LaboratoryAccreditedEu moved to the HL7 Europe Extensions IG based on the resolution of the Jira issue FHIR-57043
+// The extension keeps its canonical http://hl7.eu/fhir/StructureDefinition/laboratory-accredited and is referenced through the alias $laboratory-accredited
 
 // TODO: replace with official R6 backport extension when available.
 Extension: SpecimenFocus

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -25,7 +25,8 @@ copyright: >-
 #
 dependencies:
   hl7.fhir.uv.xver-r5.r4: 0.1.0
-  hl7.fhir.eu.extensions.r4: 1.3.0
+  # set to the next released version when the extensions IG is published
+  hl7.fhir.eu.extensions.r4: current
   hl7.fhir.eu.base: 2.0.0
 
 
@@ -129,7 +130,6 @@ parameters: #see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Pa
   special-url:
     - http://hl7.eu/fhir/StructureDefinition/information-recipient
     - http://hl7.eu/fhir/StructureDefinition/composition-basedOn-order-or-requisition
-    - http://hl7.eu/fhir/StructureDefinition/laboratory-accredited
     - http://example.org/lab-codes
   path-expansion-params: ../resources/Parameters-exp-params.json
   pin-canonicals: pin-multiples


### PR DESCRIPTION
Resolves [FHIR-57043](https://jira.hl7.org/browse/FHIR-57043) (*Persuasive*: "Extension will be moved to the EU Extensions IG, no change in content or canonical").

Counterpart in the Extensions IG: hl7-eu/extensions#9 (merged), tracked as [FHIR-56516](https://jira.hl7.org/browse/FHIR-56516).

## Changes

- Removed the `LaboratoryAccreditedEu` definition from `input/fsh/extensions/extensions-lab.fsh`; the extension is now defined in the HL7 Europe Extensions IG with an unchanged canonical `http://hl7.eu/fhir/StructureDefinition/laboratory-accredited`
- `ObservationResultsLaboratoryEu` and `ServiceRequestLabEu` are unchanged: both keep referencing the extension through the `$laboratory-accredited` alias
- Removed the canonical from `parameters.special-url`, as it is no longer defined in this guide
- Dependency `hl7.fhir.eu.extensions.r4` set to `current`, since the released 1.3.0 does not contain the extension yet — to be pinned to the next release of the extensions IG

SUSHI: 0 errors. The remaining warning is SUSHI's fallback notice for `current` packages ("Failed to download most recent ... Using most recent cached package instead"); the IG Publisher pre-installs the package from the ci-build before running SUSHI.