### PR TITLE
FHIR-57046: point the identifier guidance to the dr-comp-identifier invariant

### DIFF
--- a/input/fsh/rulesSet/rulesSet-lab.fsh
+++ b/input/fsh/rulesSet/rulesSet-lab.fsh
@@ -26,8 +26,9 @@ RuleSet: ReportSubjectRule
 
 RuleSet: ReportIdentifierRule
 * identifier /* obeys labRpt-id */
-  //TODO: do we really want to give this guidance?
-  * ^comment = "Composition.identifier SHALL be equal to one of the DiagnosticReport.identifier, if at least one exists"
+  * ^comment = """Composition.identifier SHALL be equal to one of the DiagnosticReport.identifier, if at least one exists.
+
+This guidance is enforced by the invariant dr-comp-identifier, listed in the constraints section of the [Bundle: Laboratory Report](StructureDefinition-Bundle-eu-lab.html#constraints) profile."""
 
 
 RuleSet: ReportTypeRule (element)


### PR DESCRIPTION
Resolves [FHIR-57046](https://jira.hl7.org/browse/FHIR-57046) (*Not Persuasive with Modification*: "Add to the comment to point of the location of the invariant in the bundle (invariant name: `dr-comp-identifier` in the constraints section)").

## Changes

`RuleSet: ReportIdentifierRule` — the guidance is kept and now points to where it is verified:

> Composition.identifier SHALL be equal to one of the DiagnosticReport.identifier, if at least one exists.
>
> This guidance is enforced by the invariant dr-comp-identifier, listed in the constraints section of the [Bundle: Laboratory Report](StructureDefinition-Bundle-eu-lab.html#constraints) profile.

The obsolete `//TODO: do we really want to give this guidance?` was removed. The rule set is inserted by `CompositionLabReportEu` and `DiagnosticReportLabEu`, so both profiles carry the comment.

SUSHI: 0 errors (the remaining warning is the fallback notice for the `current` extensions package).