### PR TITLE
FHIR-57047: remove the closed slicing on Observation.value[x]

### DIFF
--- a/input/fsh/rulesSet/observation-results.fsh
+++ b/input/fsh/rulesSet/observation-results.fsh
@@ -1,8 +1,6 @@
 RuleSet: ObservationResultsValueEu
-//TODO: do we really want to have this as closed slicing?
-* value[x] ^slicing.discriminator.type = #type
-* value[x] ^slicing.discriminator.path = "$this"
-* value[x] ^slicing.rules = #closed
+// The closed slicing has been removed based on the resolution of the Jira issue FHIR-57047:
+// the parent profile already slices value[x] by type and leaves the slicing open
 * valueString only string
 // * valueString MS
 * valueString ^sliceName = "valueString"


### PR DESCRIPTION
Resolves [FHIR-57047](https://jira.hl7.org/browse/FHIR-57047) (*Persuasive with Modification*: "Open the slicing on value[x]").

## Changes

`RuleSet: ObservationResultsValueEu` — the `value[x]` slicing definition (`discriminator` `type` on `$this`, `rules: closed`) was removed instead of being switched to `#open`: the parent profile `medicalTestResult-eu-core` (hl7.fhir.eu.base 2.0.0) already defines exactly that discriminator with an open slicing for `Observation.value[x]` and `Observation.component.value[x]`, so repeating it here is not needed. The obsolete TODO was replaced by a note referring to the Jira issue.

The listed slices (`valueQuantity`, `valueString`, `valueRange`, `valueRatio`, `valueTime`, `valueDateTime`, `valuePeriod`, `valueCodeableConcept`) and their constraints are unchanged; other data types are no longer prohibited.

The generated profile is byte-identical to the variant that sets `rules: open` explicitly. Compared to 2.0.0, the differential no longer carries a `slicing` entry for `Observation.value[x]` and `Observation.component.value[x]` (where it read `"rules": "closed"`) — the slicing is inherited from the parent.

SUSHI: 0 errors (the remaining warning is the fallback notice for the `current` extensions package).