### PR TITLE
Set version to 2.0.1-ci and status to draft

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -4,8 +4,8 @@ canonical: http://hl7.eu/fhir/laboratory
 name:  Hl7EuLaboratoryIg
 title: HL7 Europe Laboratory Report
 description: This guide describes how the Laboratory Report can be represented in the European REALM.
-status: active # draft | active | retired | unknown
-version: 2.0.0
+status: draft # draft | active | retired | unknown
+version: 2.0.1-ci
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2023+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use


### PR DESCRIPTION
The current build is not a release: the guide carried the released version `2.0.0` with `status: active`.

## Changes

- `version: 2.0.0` → `2.0.1-ci`
- `status: active` → `draft`

`releaseLabel` was already `ci-build`. The generated ImplementationGuide now reports `version: 2.0.1-ci` / `status: draft`, and the status propagates to the generated profiles.

SUSHI: 0 errors (the remaining warning is the fallback notice for the `current` extensions package).