### PR TITLE
Keep the identifier guidance specific to the DiagnosticReport

### DIFF
--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -40,10 +40,15 @@ Commented based on the suggestion form the 2023-05-26 meeting see https://github
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 * basedOn.extension contains DiagnosticReportBasedOnRequisition named basedOn-requisition 0..* */
 
+// The guidance of the ReportIdentifierRule is repeated here instead of inserting the rule set,
+// which would replace the comment specific to the DiagnosticReport. Keep both in sync.
 * identifier
-  * ^comment = "Usually assigned by the Information System of the diagnostic service provider for facilitating the Report search. The order id can be used as one of the Report identifier if only one report is produced for that order."
+  * ^comment = """Usually assigned by the Information System of the diagnostic service provider for facilitating the Report search. The order id can be used as one of the Report identifier if only one report is produced for that order.
 
-* insert ReportIdentifierRule
+Composition.identifier SHALL be equal to one of the DiagnosticReport.identifier, if at least one exists.
+
+This guidance is enforced by the invariant dr-comp-identifier, listed in the constraints section of the [Bundle: Laboratory Report](StructureDefinition-Bundle-eu-lab.html#constraints) profile."""
+
 * insert ReportCategoryRule
 // add binding
 /* * code 1..


### PR DESCRIPTION
`DiagnosticReportLabEu` set a comment on `identifier` and inserted `ReportIdentifierRule` right afterwards. The rule set sets the same caret path, so it silently replaced the text — the guidance on how the Report identifier is assigned never reached the generated profile (also missing in the published 2.0.0).

## Changes

`input/fsh/profiles/diagnosticReport-lab.fsh` — the `insert ReportIdentifierRule` was dropped in favour of one comment carrying both texts:

> Usually assigned by the Information System of the diagnostic service provider for facilitating the Report search. The order id can be used as one of the Report identifier if only one report is produced for that order.
>
> Composition.identifier SHALL be equal to one of the DiagnosticReport.identifier, if at least one exists.
>
> This guidance is enforced by the invariant dr-comp-identifier, listed in the constraints section of the [Bundle: Laboratory Report](StructureDefinition-Bundle-eu-lab.html#constraints) profile.

A note in the FSH source says the shared part is repeated here and has to be kept in sync with `ReportIdentifierRule`. `CompositionLabReportEu` is unchanged and keeps using the rule set.

SUSHI: 0 errors, both comments verified in the generated profiles.