### PR TITLE
FHIR-57050: allow Patient and BiologicallyDerivedProduct as specimen focus

### DIFF
--- a/input/fsh/extensions/extensions-lab.fsh
+++ b/input/fsh/extensions/extensions-lab.fsh
@@ -41,7 +41,8 @@ Title: "Specimen Focus"
 Description: "Specimen focus, Extension to represent the entity from which the specimen is collected when it is not the subject of record." 
 * insert ExtensionContext(Specimen)
 * insert SetFmmandStatusRule ( 2, trial-use)
-* value[x] only Reference(RelatedPerson or Group or Device or Substance or Location)
+// Patient and BiologicallyDerivedProduct added based on the resolution of the Jira issue FHIR-57050
+* value[x] only Reference(Patient or RelatedPerson or Group or Device or Substance or Location or BiologicallyDerivedProduct)
 
 ValueSet: ReferenceRangeLowComparator
 Id: reference-range-low-comparator

--- a/input/fsh/profiles/specimen-lab.fsh
+++ b/input/fsh/profiles/specimen-lab.fsh
@@ -8,9 +8,9 @@ Description: """This profile defines how to represent Specimens in HL7 FHIR for 
 * . ^short = "Laboratory Specimen"
 * . ^definition = "Laboratory specimen"
 * extension contains SpecimenFocus named focus 0..1
-* extension[focus].valueReference only Reference(AnimalSpecimenEuLab or Group or Device or Substance or Location)
-* extension[focus] ^short = "Animal specimen source"
-// TODO: add biological derived product?
+// The reference targets are not constrained any further here, based on the resolution of the Jira issue FHIR-57050
+* extension[focus] ^short = "The entity the specimen was collected from, when it is not the subject of record"
+* extension[focus] ^comment = "For an animal specimen source the AnimalSpecimenEuLab profile is expected to be used."
 * subject only Reference (PatientEuCore or Group or Device or Substance or Location)
 * type from LabSpecimenTypesEuVs (preferred)
   * ^comment = """If the specimen.type conveys information about the site the specimen has been collected from, then, if the bodySite if present it shall be coherent with the type.


### PR DESCRIPTION
Resolves [FHIR-57050](https://jira.hl7.org/browse/FHIR-57050) (*Persuasive with Modification*: "add BiologicallyDerivedProduct & Patient to the extension as reference target (and don't constrain it in the SpecimenProfile further)").

## Changes

**`Extension: SpecimenFocus`** — `Patient` and `BiologicallyDerivedProduct` added to the reference targets:

`Reference(Patient or RelatedPerson or Group or Device or Substance or Location or BiologicallyDerivedProduct)`

**`Profile: SpecimenEu`** — the profile no longer narrows the targets of that extension; the rule

`* extension[focus].valueReference only Reference(AnimalSpecimenEuLab or Group or Device or Substance or Location)`

was removed together with the `// TODO: add biological derived product?`. The animal use case stays valid: `AnimalSpecimenEuLab` is a `RelatedPerson` profile, and `RelatedPerson` remains among the targets — the example `Specimen-animal` is unaffected.

### Two editorial calls worth a look

- The short of `extension[focus]` was `"Animal specimen source"`, which no longer matches the widened targets; it now reads "The entity the specimen was collected from, when it is not the subject of record".
- Since the removed type constraint was the only place naming `AnimalSpecimenEuLab`, a comment keeps that pointer: "For an animal specimen source the AnimalSpecimenEuLab profile is expected to be used."

Say the word if either should be dropped or worded differently.

SUSHI: 0 errors (the remaining warning is the fallback notice for the `current` extensions package).