### PR TITLE
FHIR-57051: use the R5 backport extension for the specimen collection body site

### DIFF
--- a/input/fsh/alias-lab.fsh
+++ b/input/fsh/alias-lab.fsh
@@ -35,7 +35,6 @@ Alias: $specimen-feature-type-r5 = http://hl7.org/fhir/5.0/StructureDefinition/e
 Alias: $specimen-collection-device-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.device
 Alias: $specimen-collection-body-site-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.bodySite
 Alias: $specimen-collection-body-site-reference-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.bodySite.reference
-Alias: $bodySite-reference = http://hl7.org/fhir/StructureDefinition/bodySite
 Alias: $event-performerFunction = http://hl7.org/fhir/StructureDefinition/event-performerFunction
 Alias: $iso21090-ADXP-streetName = http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName
 Alias: $iso21090-ADXP-houseNumber = http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber

--- a/input/fsh/profiles/specimen-lab.fsh
+++ b/input/fsh/profiles/specimen-lab.fsh
@@ -26,9 +26,10 @@ Otherwise the relationship is recorded in the Specimen.request element"""
 * collection
   * bodySite from http://hl7.org/fhir/ValueSet/body-site (preferred)
     * ^comment = "If the specimen.type conveys information about the site the specimen has been collected from, then, if the bodySite is present, it shall be coherent with the type"
-  //TODO: extension not allowed on Specimen, replace with backport extension
-  * extension contains $bodySite-reference named bodySite 0..1
-  * extension[bodySite].valueReference only Reference(BodyStructureEuCore)
+    // The R5 backport extension replaces the bodySite extension, which has no Specimen context,
+    // based on the resolution of the Jira issue FHIR-57051
+    * extension contains $specimen-collection-body-site-r5 named bodySite 0..1
+    * extension[bodySite].valueReference only Reference(BodyStructureEuCore)
 * processing.additive only Reference(Substance or SpecimenAdditiveSubstance)
 * container
   * type from LabSpecimenContainerEu (preferred)


### PR DESCRIPTION
Resolves [FHIR-57051](https://jira.hl7.org/browse/FHIR-57051) (*Persuasive*: replace the invalid extension with [ext-R5-Specimen.col.bodySite](https://hl7.org/fhir/uv/xver-r5.r4/0.1.0/StructureDefinition-ext-R5-Specimen.col.bodySite.html)).

## Changes

`Profile: SpecimenEu` — `http://hl7.org/fhir/StructureDefinition/bodySite` (context: `Procedure.bodySite` only, so it was never allowed here) is replaced by the cross-version extension `http://hl7.org/fhir/5.0/StructureDefinition/extension-Specimen.collection.bodySite` from `hl7.fhir.uv.xver-r5.r4`, which is already a dependency. The alias for it existed as well.

Note the placement changed with it: the backport extension declares the context `Specimen.collection.bodySite`, not `Specimen.collection`, since it carries the reference half of what became a `CodeableReference` in R5. It is therefore nested under the `bodySite` element:

```
* collection
  * bodySite from http://hl7.org/fhir/ValueSet/body-site (preferred)
    * extension contains $specimen-collection-body-site-r5 named bodySite 0..1
    * extension[bodySite].valueReference only Reference(BodyStructureEuCore)
```

Generated element: `Specimen.collection.bodySite.extension:bodySite` with `valueReference` constrained to `bodyStructure-eu-core` (before: `Specimen.collection.extension:bodySite`). No example uses the extension, so none had to be touched.

The now unused alias `$bodySite-reference` was removed; `$specimen-collection-body-site-reference-r5` stays untouched.

SUSHI: 0 errors (the remaining warning is the fallback notice for the `current` extensions package).