### PR TITLE
FHIR-57052: compare only Reference.reference in dr-comp-enc and dr-comp-subj

### DIFF
--- a/input/fsh/profiles/bundle-lab.fsh
+++ b/input/fsh/profiles/bundle-lab.fsh
@@ -104,18 +104,21 @@ Description: "Clinical document used to represent a Laboratory Report for the sc
 /// INVARIANTS
 //===================================
 
+// Based on the resolution of the Jira issue FHIR-57052 the two invariants below only compare
+// Reference.reference, and only when both references carry it. Comparing the complete Reference
+// objects caused false negatives, as FHIRPath '=' compares complex objects structurally and
+// semantically equal references may differ in display, identifier or reference style.
+
 Invariant: dr-comp-enc
-Description: "DiagnosticReport and Composition SHALL have the same encounter"
+Description: "DiagnosticReport and Composition SHOULD have the same encounter"
 /* Expression: "( (entry:composition.resource.encounter.empty() and entry:diagnosticReport.resource.encounter.empty() ) or entry:composition.resource.encounter = entry:diagnosticReport.resource.encounter )" */
-// TODO: Consider comparing encounter.reference instead of the full Reference object. FHIRPath '=' compares complex objects structurally, so semantically equal references may fail if display, identifier, or reference style differs.
-Expression: "( (entry.resource.ofType(Composition).encounter.empty() and entry.resource.ofType(DiagnosticReport).encounter.empty() ) or entry.resource.ofType(Composition).encounter = entry.resource.ofType(DiagnosticReport).encounter )"
-Severity:    #error
+Expression: "(entry.resource.ofType(Composition).encounter.reference.exists() and entry.resource.ofType(DiagnosticReport).encounter.reference.exists()) implies entry.resource.ofType(Composition).encounter.reference = entry.resource.ofType(DiagnosticReport).encounter.reference"
+Severity:    #warning
 
 Invariant: dr-comp-subj
-Description: "DiagnosticReport and Composition SHALL have the same subject"
-// TODO: Consider comparing subject.reference instead of the full Reference object. FHIRPath '=' compares complex objects structurally, so semantically equal references may fail if display, identifier, or reference style differs.
-Expression: "( (entry.resource.ofType(Composition).subject.empty() and entry.resource.ofType(DiagnosticReport).subject.empty() ) or entry.resource.ofType(Composition).subject = entry.resource.ofType(DiagnosticReport).subject )"
-Severity:    #error
+Description: "DiagnosticReport and Composition SHOULD have the same subject"
+Expression: "(entry.resource.ofType(Composition).subject.reference.exists() and entry.resource.ofType(DiagnosticReport).subject.reference.exists()) implies entry.resource.ofType(Composition).subject.reference = entry.resource.ofType(DiagnosticReport).subject.reference"
+Severity:    #warning
 
 
 Invariant: dr-comp-type


### PR DESCRIPTION
Resolves [FHIR-57052](https://jira.hl7.org/browse/FHIR-57052) (*Persuasive with Modification*: "Change the invariant to only compare Reference.reference (if existing in both References). Issue Severity = Warning").

## Changes

`BundleLabReportEu` — `dr-comp-enc` and `dr-comp-subj`:

```
(entry.resource.ofType(Composition).subject.reference.exists() and entry.resource.ofType(DiagnosticReport).subject.reference.exists())
  implies entry.resource.ofType(Composition).subject.reference = entry.resource.ofType(DiagnosticReport).subject.reference
```

- Only `Reference.reference` is compared, so semantically equal references no longer fail on differing `display`, `identifier` or reference style
- The comparison only applies when both references carry `reference`; the previous `empty() and empty()` branch is covered by the implication
- `Severity: #error` → `#warning`
- The resolved TODOs were replaced by a note referring to the Jira issue

### One editorial call

Both descriptions said "SHALL have the same encounter/subject", which contradicts a warning-level constraint; they now read "SHOULD". Say the word if you want the SHALL wording back.

All example bundles satisfy the new invariants (`subject` identical in all five, `encounter` present and identical in `Bundle-IT-CDA2FHIR-17e2cad1`). SUSHI: 0 errors.