### PR TITLE
FHIR-57057: require an actual value in eu-lab-1 and eu-lab-2

### DIFF
--- a/input/fsh/profiles/observation-lab.fsh
+++ b/input/fsh/profiles/observation-lab.fsh
@@ -78,14 +78,18 @@ That's why it is important to explicitly include informaiton about measurement m
   * code from LaboratoryResultStandardEuVs (preferred)
   * insert ObservationResultsValueEu
 
-//TODO: use hasValue in next release
+// Based on the resolution of the Jira issue FHIR-57057 both invariants require an actual value
+// instead of an element that only carries extensions, such as a data absent reason.
+// hasValue() covers the primitive types; for the complex ones it is always false, so there the
+// check is that the value has children other than its extensions. The cross version extension
+// has to carry a value as well, its bare presence is not enough.
 
 Invariant: eu-lab-1
-Description: "If observation status is other then \"registered\" or \"cancelled\", at least one of these Observation elements shall be provided:  \"value\", the R5 \"value[x]\" extension, \"dataAbsentReason\", \"hasMember\" or \"component\""
+Description: "If observation status is other then \"registered\" or \"cancelled\", at least one of these Observation elements shall be provided with an actual value:  \"value\", the R5 \"value[x]\" extension, \"dataAbsentReason\", \"hasMember\" or \"component\""
 Severity: #error
-Expression: "(status in ('registered'|'cancelled')) or value.exists() or extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value').exists() or hasMember.exists() or component.exists() or dataAbsentReason.exists()"
+Expression: "(status in ('registered'|'cancelled')) or value.hasValue() or value.children().exclude(value.extension).exists() or extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value').value.exists() or hasMember.exists() or component.exists() or dataAbsentReason.exists()"
 
 Invariant: eu-lab-2
-Description: "If observation status is other then \"registered\" or \"cancelled\", every Observation.component shall provide one of these elements:  \"value\", the R5 \"component.value[x]\" extension or \"dataAbsentReason\""
+Description: "If observation status is other then \"registered\" or \"cancelled\", every Observation.component shall provide one of these elements with an actual value:  \"value\", the R5 \"component.value[x]\" extension or \"dataAbsentReason\""
 Severity: #error
-Expression: "(status in ('registered'|'cancelled')) or component.all(value.exists() or extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.component.value').exists() or dataAbsentReason.exists())"
+Expression: "(status in ('registered'|'cancelled')) or component.all(value.hasValue() or value.children().exclude(value.extension).exists() or extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.component.value').value.exists() or dataAbsentReason.exists())"


### PR DESCRIPTION
Resolves [FHIR-57057](https://jira.hl7.org/browse/FHIR-57057) (*Persuasive*: "Both invariants will utilize hasValue() to make sure, that an actual value (and not only an extension without a value) is provided. Every .exists() will be replaced by .hasValue()").

## What the invariants do now

```
(status in ('registered'|'cancelled'))
 or value.hasValue()
 or value.children().exclude(value.extension).exists()
 or extension.where(url='http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value').value.exists()
 or hasMember.exists() or component.exists() or dataAbsentReason.exists()
```

`eu-lab-2` applies the same three value checks inside `component.all(...)`.

## Which operand decides which case

The two value operands do not overlap — each one is decisive for one half of the choice element, measured with fhirpath.js against the R4 model:

| value[x] | `value.hasValue()` | `value.children().exclude(value.extension).exists()` |
|---|---|---|
| `valueString: "positive"` | **true** | false |
| `_valueString` with only a data-absent-reason | **false** | false |
| `valueDateTime: 2026-01-01` | **true** | false |
| `valueQuantity: 5.4 mmol/L` | false | **true** |
| `valueQuantity: {extension:[data-absent-reason]}` | false | **false** |
| `valueCodeableConcept` with a coding | false | **true** |

- **primitive values** (`valueString`, `valueDateTime`, `valueTime`): `hasValue()` alone decides. `_valueString` exists only to carry `id`/`extension`, so an element with just a data-absent-reason and no `valueString` is present in the tree but has no value — exactly the case the issue is about. The second operand contributes nothing here.
- **complex values** (`valueQuantity`, `valueCodeableConcept`, `valueRange`, `valueRatio`, `valuePeriod`): `hasValue()` is false by definition, so it cannot be used — a plain `valueQuantity` of 5.4 mmol/L would violate an error-severity invariant. There the check is that the value has content of its own: `children()` of a `valueQuantity: {extension:[data-absent-reason]}` is only that extension, while a real Quantity has value/unit/system/code.

This is why the resolution's "every .exists() will be replaced by .hasValue()" cannot be applied literally: `hasValue()` also returns false for `dataAbsentReason`, `hasMember`, `component` and the cross-version extension.

- **the R5 value extension**: `.value.exists()` instead of the bare presence of the extension, in the spirit of the resolution
- `hasMember`, `component`, `dataAbsentReason` keep `.exists()`; they are complex elements where presence is the point

## Verification

The expressions were read back out of the generated profile and evaluated with fhirpath.js (R4 model):

- 29 cases, all as expected — every real value type true, `valueQuantity` and `_valueString` carrying only a data absent reason false, the R5 extension without a value false, `status` registered/cancelled true
- all 51 Observations in the generated examples satisfy both invariants

SUSHI: 0 errors.