### PR TITLE
FHIR-57058: rework the LabStudyTypesEuVs description

### DIFF
--- a/input/fsh/terminologies/lab-studyType-lab.fsh
+++ b/input/fsh/terminologies/lab-studyType-lab.fsh
@@ -1,12 +1,14 @@
 ValueSet:      LabStudyTypesEuVs
 Id:	       lab-studyType-eu-lab
 Title:	       "Laboratory Study Types"
-// TODO: Description should be adjusted according to the final set of EU study types.
+// The formatting of the description was improved based on the resolution of the Jira issue FHIR-57058
 Description:   """Laboratory Study Types
-Notes:
-Note 1:26436-6 (Laboratory studies) enables issuing a report putting together observations from multiple specialties (disciplines) in the same text block, allowing delivery of a global interpretation comment at the end of the text block that will be rendered at the end of the report.
-Note 2:Mycology and parasitology, as well as bacteriology, are part of the 18725-2 (Microbiology studies (set)) studies.
-Note 3:Virology MAY be included in 18725-2 (MICROBIOLOGY STUDIES) or 18727-8 (SEROLOGY STUDIES) or split between both study types, depending upon the Content Creator Actor’s choice.
+
+**Notes:**
+
+1. 26436-6 (Laboratory studies) enables issuing a report putting together observations from multiple specialties (disciplines) in the same text block, allowing delivery of a global interpretation comment at the end of the text block that will be rendered at the end of the report.
+2. Mycology and parasitology, as well as bacteriology, are part of the 18725-2 (Microbiology studies (set)) studies.
+3. Virology MAY be included in 18725-2 (MICROBIOLOGY STUDIES) or 18727-8 (SEROLOGY STUDIES) or split between both study types, depending upon the Content Creator Actor’s choice.
 """
 
 

--- a/input/fsh/terminologies/lab-studyType-lab.fsh
+++ b/input/fsh/terminologies/lab-studyType-lab.fsh
@@ -7,8 +7,7 @@ Description:   """Laboratory Study Types
 **Notes:**
 
 1. 26436-6 (Laboratory studies) enables issuing a report putting together observations from multiple specialties (disciplines) in the same text block, allowing delivery of a global interpretation comment at the end of the text block that will be rendered at the end of the report.
-2. Mycology and parasitology, as well as bacteriology, are part of the 18725-2 (Microbiology studies (set)) studies.
-3. Virology MAY be included in 18725-2 (MICROBIOLOGY STUDIES) or 18727-8 (SEROLOGY STUDIES) or split between both study types, depending upon the Content Creator Actor’s choice.
+2. Mycology, parasitology, bacteriology and virology are part of the 18725-2 (Microbiology studies (set)) studies.
 """
 
 


### PR DESCRIPTION
Resolves [FHIR-57058](https://jira.hl7.org/browse/FHIR-57058) (*Not Persuasive with Modification*: "The formatting of the description will be improved for better readability").

## 1. Formatting (the resolution)

`ValueSet.description` is markdown, where single line breaks collapse, so the five lines were rendered as a single paragraph — and the note labels had no space after the colon.

Before:

```
Laboratory Study Types
Notes:
Note 1:26436-6 (Laboratory studies) enables ...
Note 2:Mycology and parasitology, as well as bacteriology, are part of the 18725-2 (Microbiology studies (set)) studies.
Note 3:Virology MAY be included in 18725-2 (MICROBIOLOGY STUDIES) or 18727-8 (SEROLOGY STUDIES) or split between both study types, depending upon the Content Creator Actor's choice.
```

After:

```
Laboratory Study Types

**Notes:**

1. 26436-6 (Laboratory studies) enables issuing a report putting together observations from multiple specialties (disciplines) in the same text block, allowing delivery of a global interpretation comment at the end of the text block that will be rendered at the end of the report.
2. Mycology, parasitology, bacteriology and virology are part of the 18725-2 (Microbiology studies (set)) studies.
```

## 2. The virology note, beyond the resolution

The resolution declared the content part not persuasive, but the review turned up a concrete inconsistency, so this was fixed on purpose — please confirm when reviewing:

The note read "Virology MAY be included in 18725-2 (MICROBIOLOGY STUDIES) or **18727-8 (SEROLOGY STUDIES)** or split between both study types, depending upon the Content Creator Actor's choice." That choice does not exist here: `18727-8` was commented out on 2023-09-06 (`e0c06fb`), when the value set was cut down from the 20 XD-LAB study types to the 7 agreed between the member states. The note kept offering it ever since — `hl7.fhir.eu.laboratory#0.1.1` and `#2.0.0` both ship 7 codes without serology.

With serology gone, the note said the same thing as the note above it, so the two were merged into one listing all microbiology disciplines.

The `// TODO: Description should be adjusted according to the final set of EU study types.` was replaced by a note referring to the Jira issue.

SUSHI: 0 errors. Verified in the generated ValueSet: every code named in the description (`26436-6`, `18725-2`) is part of the value set.