### PR TITLE
FHIR-57208: allow a status reason on the observation and the report

### DIFF
--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -15,6 +15,14 @@ Description: "DiagnosticReport used to represent an entry of a Laboratory Report
   * ^definition = "This extension implements the R5 composition element. It allow to link this DiagnosticReport with the Composition documenting this Laboratory Report."
   *  valueReference only Reference(CompositionLabReportEu)
 
+// The core extension is used instead of a new one, based on the resolution of the Jira issue FHIR-57208
+* extension contains $event-statusReason named statusReason 0..1
+* extension[statusReason]
+  * ^short = "Reason for the current status"
+  * ^definition = "Captures the reason for the current state of this report, which is of interest whenever the report was withdrawn or revised."
+
+* status ^comment = "The statuses amended, corrected, appended, cancelled and entered-in-error SHOULD be accompanied by the reason for that status, conveyed in the statusReason extension."
+
 /*
 content to be referred...
 Specimen Collection 1.3.6.1.4.1.19376.1.3.1.2

--- a/input/fsh/profiles/observation-lab.fsh
+++ b/input/fsh/profiles/observation-lab.fsh
@@ -19,7 +19,8 @@ This observation may represent the result of a simple laboratory test such as he
   DeviceLabTestKit named labTestKit 0..* and
   ObservationCertifiedRefMaterialCodeable named certifiedRefMaterialCodeable 0..* and
   ObservationCertifiedRefMaterialIdentifer named certifiedRefMaterialIdentifer 0..* and
-  $laboratory-accredited named accredited 0..1
+  $laboratory-accredited named accredited 0..1 and
+  $event-statusReason named statusReason 0..1
 
 * extension[labTestKit]
   * ^short = "Laboratory Test Kit"
@@ -27,8 +28,13 @@ This observation may represent the result of a simple laboratory test such as he
 * extension[accredited]
   * ^short = "Accredited test"
   * ^definition = "Indicates that this laboratory test was/is accredited."
+// The core extension is used instead of a new one, based on the resolution of the Jira issue FHIR-57208
+* extension[statusReason]
+  * ^short = "Reason for the current status"
+  * ^definition = "Captures the reason for the current state of this observation, which is of interest whenever the result was withdrawn or revised."
 
 * status ^short = "Status of this observation (e.g. preliminary, final,...)"
+* status ^comment = "The statuses amended, corrected, cancelled and entered-in-error SHOULD be accompanied by the reason for that status, conveyed in the statusReason extension."
 
 * referenceRange.modifierExtension contains
   ObservationReferenceRangeLowComparator named lowComparator 0..1 and


### PR DESCRIPTION
Resolves [FHIR-57208](https://jira.hl7.org/browse/FHIR-57208) (*Persuasive with Modification*).

## Changes

**`ObservationResultsLaboratoryEu`** and **`DiagnosticReportLabEu`**:

```
* extension contains $event-statusReason named statusReason 0..1
```

with a short and definition on the slice, plus the guidance the resolution asks for on `status`:

- Observation: "The statuses amended, corrected, cancelled and entered-in-error SHOULD be accompanied by the reason for that status, conveyed in the statusReason extension."
- DiagnosticReport: same, with `appended` included

No invariant enforces it, as requested.

## Deviation from the resolution — please confirm

The resolution asks for a new `Extension: status-reason` in the Extensions IG, under the condition that the base/core/extension group agrees, with the Jira ticket for it still to be created. That step looks unnecessary: HL7 already publishes an extension that fits exactly, and this guide loads it anyway.

`http://hl7.org/fhir/StructureDefinition/event-statusReason` in `hl7.fhir.uv.extensions#5.3.0`:

- status **active** (it was `draft` in R4 core, it is not any more)
- context: **Observation, DiagnosticReport**, DocumentReference, SupplyDelivery, DeviceUsage, DeviceUseStatement
- `value[x]`: CodeableConcept, no fixed binding — so a jurisdiction can bind its own reasons
- title "Event status reason", "Captures the reason for the current state of the resource."

SUSHI resolves `hl7.fhir.uv.extensions.r4#5.3.0` for this guide on its own, so no dependency had to be added, and the alias `$event-statusReason` was already present in `alias-lab.fsh` (unused until now). The Extensions IG states in its scope that it wants to "avoid duplication by complementing, rather than duplicating, existing FHIR core extensions", which is the same conclusion.

If the group still wants an own EU extension, this PR is the wiring for it — only the canonical in the two `extension contains` rules would change.

## Status codes

The guidance names only statuses the respective resource actually has: `corrected` is a child of `amended` in the R4 `observation-status` code system, and `appended` exists in `diagnostic-report-status` only.

SUSHI: 0 errors. Both slices verified in the generated profiles (`Observation.extension:statusReason`, `DiagnosticReport.extension:statusReason`, each 0..1 on the core extension).