### PR TITLE
FHIR-57547: stop narrowing the subject target types

### DIFF
--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -64,6 +64,13 @@ This guidance is enforced by the invariant dr-comp-identifier, listed in the con
 
 * insert ReportTypeRule ( code )
 * insert ReportSubjectRule
+// Based on the resolution of the Jira issue FHIR-57547 the target types are no longer narrowed:
+// the list below is the one of the base resource, with the Patient pinned to the EU core profile.
+// The requested open slicing is not possible, as FHIR only allows slicing on repeating or choice
+// elements and subject is 0..1.
+* subject only Reference(PatientEuCore or Group or Location or Device)
+  * ^short = "The patient this report is about"
+
 * insert ReportEncounterRule
 * performer 
   /* * obeys labRpt-author */

--- a/input/fsh/profiles/serviceRequest-lab.fsh
+++ b/input/fsh/profiles/serviceRequest-lab.fsh
@@ -15,7 +15,12 @@ Description: """This profile defines how to represent an laboratory orders using
 * identifier 1..
 * code from LabOrderCodesEuVs (preferred)
 * subject 1..
-* subject only Reference (PatientEuCore or PatientAnimalEu or Group or Location or Device)
+// Based on the resolution of the Jira issue FHIR-57547 the target types are no longer narrowed:
+// the list below is the one of the base resource, with the Patient pinned to the EU core profile.
+// The requested open slicing is not possible, as FHIR only allows slicing on repeating or choice
+// elements and subject is 1..1.
+* subject only Reference(PatientEuCore or Group or Location or Device)
+  * ^short = "The patient the laboratory order is for"
 * requisition ^short = "Composite Request ID."
 * specimen	only Reference (SpecimenEu)
   * ^short = "Specimens to be used by the laboratory procedure"


### PR DESCRIPTION
Resolves [FHIR-57547](https://jira.hl7.org/browse/FHIR-57547) (*Persuasive with Modification*: "We do not support veterinary Medicine in EHDS. Remove enumerated resource type restrictions and replace with open slicing on type and a slice for Patient EU").

## The requested open slicing is not possible

FHIR allows slicing only on repeating or choice elements, and `subject` is 0..1 on DiagnosticReport and 1..1 on ServiceRequest. SUSHI rejects it outright:

```
error Cannot slice element 'subject' since FHIR only allows slicing on choice elements
      (e.g., value[x]) or elements with max > 1
```

## What was done instead

Both profiles now list exactly the target types of the base resource, with the Patient pinned to the EU core profile:

```
* subject only Reference(PatientEuCore or Group or Location or Device)
```

That is the semantics the slicing was meant to express: the type set is not narrowed any further (`Patient | Group | Location | Device` is what R4 allows on both elements — verified against the base StructureDefinitions), a Patient subject has to be `patient-eu-core`, and the animal patient profile is no longer enumerated.

| profile | before | after |
|---|---|---|
| `DiagnosticReportLabEu` | no own rule; inherited `Patient \| Group \| Location \| Device` from `DiagnosticReportEuCore`, unprofiled | `patient-eu-core \| Group \| Location \| Device` |
| `ServiceRequestLabEu` | `PatientEuCore \| PatientAnimalEu \| Group \| Location \| Device` | `patient-eu-core \| Group \| Location \| Device` |

ServiceRequest was included because it carried the last enumeration naming `PatientAnimalEu` — leaving it would have kept exactly the state the resolution removes, one profile over.

The unresolvable canonical `http://hl7.eu/fhir/base/StructureDefinition/patient-animal-eu-core` that the issue reported for 2.0.0 is already gone from the CI build, as the reporter noted.

## Not touched

The `PatientAnimalEu` profile (`Patient-animal-eu-lab`) and its example stay as they are — the resolution asks for the enumerations to go, not for the profile to be withdrawn, and removing a published artifact would be a breaking change. It is simply no longer named as a possible subject.

All five example bundles reference a Patient that already claims `patient-eu-core`, so no example is affected. SUSHI: 0 errors.