### PR TITLE
FHIR-57901: allow a patient or related person as specimen collector

### DIFF
--- a/input/fsh/alias-lab.fsh
+++ b/input/fsh/alias-lab.fsh
@@ -51,7 +51,7 @@ Alias: $sexForClinicalUse = http://hl7.org/fhir/StructureDefinition/patient-sexP
 Alias: $recordedSexOrGender = http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender
 Alias: $observation-triggeredBy-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.triggeredBy
 Alias: $observation-value-r5 = http://hl7.org/fhir/5.0/StructureDefinition/extension-Observation.value
-Alias: $diagnosticReport-link-xver = http://hl7.org/fhir/StructureDefinition/alternate-reference
+Alias: $alternate-reference = http://hl7.org/fhir/StructureDefinition/alternate-reference
 
 // Extensions from EU Extensions:
 Alias: $composition-diagnosticReportReference = http://hl7.eu/fhir/extensions/StructureDefinition/composition-diagnosticReportReference

--- a/input/fsh/profiles/diagnosticReport-lab.fsh
+++ b/input/fsh/profiles/diagnosticReport-lab.fsh
@@ -109,7 +109,7 @@ This guidance is enforced by the invariant dr-comp-identifier, listed in the con
     * display 1..1
       * ^definition = "Text stating that instead of a reference to a Media resource, a DocumentReference resource is linked through the cross-version extension 'link'."
       * ^short = "Text stating use of cross-version extension 'link'"
-    * extension contains $diagnosticReport-link-xver named link 0..1
+    * extension contains $alternate-reference named link 0..1
     * extension[link]
       * ^definition = "Reference to a DocumentReference containing additional information/attachments associated with this report."
       * ^short = "DocumentReference containing additional information/attachments"

--- a/input/fsh/profiles/specimen-lab.fsh
+++ b/input/fsh/profiles/specimen-lab.fsh
@@ -30,6 +30,19 @@ Otherwise the relationship is recorded in the Specimen.request element"""
     // based on the resolution of the Jira issue FHIR-57051
     * extension contains $specimen-collection-body-site-r5 named bodySite 0..1
     * extension[bodySite].valueReference only Reference(BodyStructureEuCore)
+
+// Patient and RelatedPerson, the collectors added in R5, are conveyed with the alternate-reference
+// extension, based on the resolution of the Jira issue FHIR-57901. This is the mechanism the
+// cross version profile for the R5 Specimen uses for this element as well.
+* collection.collector
+  * ^short = "Who collected the specimen"
+  * ^comment = """In FHIR R4 this element can only refer to a Practitioner or a PractitionerRole.
+When the specimen was collected by the patient or by a related person, the reference is conveyed in the alternate-reference extension instead."""
+* collection.collector.extension contains $alternate-reference named collector 0..1
+* collection.collector.extension[collector]
+  * ^short = "Patient or related person who collected the specimen"
+  * valueReference only Reference(PatientEuCore or RelatedPerson)
+
 * processing.additive only Reference(Substance or SpecimenAdditiveSubstance)
 * container
   * type from LabSpecimenContainerEu (preferred)


### PR DESCRIPTION
Resolves [FHIR-57901](https://jira.hl7.org/browse/FHIR-57901) (*Persuasive*: "Patient and RelatedPerson with backport extensions on Specimen.collector will be added").

## Changes

`SpecimenEu`:

```
* collection.collector.extension contains $alternate-reference named collector 0..1
* collection.collector.extension[collector]
  * ^short = "Patient or related person who collected the specimen"
  * valueReference only Reference(PatientEuCore or RelatedPerson)
```

plus a comment on `collection.collector` stating that R4 only allows Practitioner and PractitionerRole there, and that a patient or related person is conveyed through the extension.

## Which backport extension

`hl7.fhir.uv.xver-r5.r4#0.1.0` has no `extension-Specimen.collection.collector` — cross-version extensions of that shape only exist for elements that are *new* in R5, while `collector` merely gained reference targets. For that case the mechanism is `http://hl7.org/fhir/StructureDefinition/alternate-reference` ("Used when the target of the reference has a type that is not allowed by the definition of the element. In general, this should only arise when wrangling between versions using cross-version extensions", context `Reference`, status active in `hl7.fhir.uv.extensions#5.3.0`).

That is exactly what the official cross-version profile does — `profile-Specimen` in the xver package constrains `Specimen.collection.collector.extension:collector` to `alternate-reference`, with the comment:

> The standard extension `alternate-reference` has been mapped as the representation of FHIR R5 element `Specimen.collection.collector` with unmapped reference targets: Patient, RelatedPerson.

So this PR follows the same construction, with the Patient pinned to `patient-eu-core` and `RelatedPerson` unprofiled, as EU base has no RelatedPerson profile.

## Alias rename

The IG already used this extension for `DiagnosticReport.media.link`, under the alias `$diagnosticReport-link-xver`. Since it is now used on Specimen as well, the alias was renamed to `$alternate-reference` and the single existing usage updated — no change to the generated DiagnosticReport profile.

SUSHI: 0 errors. Verified in the generated profile: `Specimen.collection.collector.extension:collector` 0..1 on `alternate-reference` with `valueReference` limited to `patient-eu-core | RelatedPerson`, and `DiagnosticReport.media.link.extension:link` unchanged.