### PR TITLE
FHIR-57055: allow a substance or a biologically derived product as focus

### DIFF
--- a/input/fsh/profiles/observation-lab.fsh
+++ b/input/fsh/profiles/observation-lab.fsh
@@ -61,8 +61,9 @@ This observation may represent the result of a simple laboratory test such as he
 * code ^definition = "Describes what was observed. Sometimes this is called the observation \"name\".  In this profile this code represents either a simple laboratory test or a laboratory study with multiple child observations"
 * code ^comment = "In the context of this Observation-laboratory profile, when the observation plays the role of a grouper of member sub-observations, the code represent the group (for instance a panel code). In case no code is available, at least a text shall be provided."
 
-//TODO: add Substance and PatientAnimal as soon base is extended, needs discussion what has to be supported
-* focus only Reference(PatientEuCore or AnimalSpecimenEuLab or Group or Device or LocationEuCore)  // If the observation belongs to a human patient but specimen is collected from an animal, then the focus of the observation is the animal specimen.
+// Substance and BiologicallyDerivedProduct added based on the resolution of the Jira issue FHIR-57055,
+// after they were added to the focus of the EU core profile
+* focus only Reference(PatientEuCore or AnimalSpecimenEuLab or Group or Device or LocationEuCore or Substance or BiologicallyDerivedProduct)  // If the observation belongs to a human patient but specimen is collected from an animal, then the focus of the observation is the animal specimen.
 
 * performer 1..
 * dataAbsentReason ^short = "Provides a reason why the expected value is missing."

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -27,7 +27,8 @@ dependencies:
   hl7.fhir.uv.xver-r5.r4: 0.1.0
   # set to the next released version when the extensions IG is published
   hl7.fhir.eu.extensions.r4: current
-  hl7.fhir.eu.base: 2.0.0
+  # set to the next released version when the base IG is published
+  hl7.fhir.eu.base: current
 
 
 


### PR DESCRIPTION
Resolves [FHIR-57055](https://jira.hl7.org/browse/FHIR-57055) (*Persuasive with Modification*: "Add Substance and BiologicalDerived Product to Observation.focus (After being added to the EU base/core profiles). Check Specimen.subject to include patientAnimal as well").

## Changes

`ObservationResultsLaboratoryEu`:

```
* focus only Reference(PatientEuCore or AnimalSpecimenEuLab or Group or Device or LocationEuCore or Substance or BiologicallyDerivedProduct)
```

The `//TODO: add Substance and PatientAnimal as soon base is extended` was replaced by a note referring to the Jira issue.

## The precondition and the dependency

The parent `MedicalTestResultEuCore` narrows `Observation.focus`, and a derived profile cannot widen it. In the released `hl7.fhir.eu.base#2.0.0` the targets are `patient-eu-core | RelatedPerson | Group | Device | location-eu-core` — the two new ones were added to the base only recently (hl7-eu/base-multi-versions#26, FHIR-56556) and are not in a release yet.

The dependency therefore moves to the ci-build:

```yaml
# set to the next released version when the base IG is published
hl7.fhir.eu.base: current
```

Verified against the downloaded `hl7.fhir.eu.base#current` (2.0.1-ci): its `Observation.focus` now lists `Substance` and `BiologicallyDerivedProduct`, and the generated laboratory profile carries them through. SUSHI: 0 errors (the remaining warning is the fallback notice for the `current` extensions package).

## Specimen.subject left as it is

The second half of the resolution asks to "check Specimen.subject to include patientAnimal as well". It stays `PatientEuCore or Group or Device or Substance or Location`, without `PatientAnimalEu`:

[FHIR-57547](https://jira.hl7.org/browse/FHIR-57547) states "We do not support veterinary Medicine in EHDS" and had exactly these enumerations stripped of the animal patient profile (#136, merged). Adding it back here would reintroduce that, one element over. The animal case continues to work through the `SpecimenFocus` extension with `AnimalSpecimenEuLab`, which is where this guide represents a specimen taken from an animal while the patient of record is human.

Worth a note back on the issue, since the two resolutions pull in different directions — FHIR-57055 was resolved on 2026-08-17, FHIR-57547 on 2026-06-08.